### PR TITLE
feat: increase default subdomain page limit to 10,000

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -59,7 +59,7 @@ export const config = {
   subdomains: {
     enabled: process.env.SUBDOMAINS_ENABLED !== 'false', // default true
     maxLength: parseInt(process.env.SUBDOMAIN_MAX_LENGTH || '63', 10),
-    maxPagesPerSubdomain: parseInt(process.env.SUBDOMAIN_MAX_PAGES || '100', 10),
+    maxPagesPerSubdomain: parseInt(process.env.SUBDOMAIN_MAX_PAGES || '10000', 10),
     reservedNames: (process.env.SUBDOMAIN_RESERVED_NAMES || 'www,api,mail,admin,blog,docs,help,support,status,billing,account,accounts,app,apps,dashboard,cdn,static,assets,img,images,image,forum,forums,wiki,news,m,dev,staging,test,testing,sandbox,beta,alpha,lab,labs,store,shop,pricing,legal,privacy,terms,security, careers,jobs,contact,about,home').split(',').filter(Boolean),
     baseDomain: process.env.SUBDOMAIN_BASE_DOMAIN || 'zenbin.org', // Fixed: zenbin.org
   },


### PR DESCRIPTION
## Summary

- Increase  default from **100** to **10,000**
- Still configurable via  environment variable

## Context

The current limit of 100 pages per subdomain is too restrictive for production deployments. This raises the default to 10,000 while keeping it configurable.

## Files Changed

- `src/config.ts` — Updated default value for `subdomains.maxPagesPerSubdomain`

## Testing

- Existing `config.subdomains.maxPagesPerSubdomain` usage in `src/routes/pages.ts` continues to work unchanged
- Env var override still works: `SUBDOMAIN_MAX_PAGES=5000`