### PR TITLE
feat: add video support with filesystem storage (100MB max)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 
 # Data
 data/
+videos/
 
 # Environment
 .env

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,17 @@ export const config = {
     'image/svg+xml',
   ],
 
+  // Video settings
+  videoStoragePath: process.env.VIDEO_STORAGE_PATH || './data/videos',
+  maxVideoSize: parseInt(process.env.MAX_VIDEO_SIZE || '104857600', 10), // 100MB default
+  allowedVideoTypes: [
+    'video/mp4',
+    'video/webm',
+    'video/ogg',
+    'video/quicktime',
+    'video/x-msvideo',
+  ],
+
   // Rate Limiting
   rateLimitWindowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS || '60000', 10),
   rateLimitMaxRequests: parseInt(process.env.RATE_LIMIT_MAX_REQUESTS || '100', 10),

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { cors } from 'hono/cors';
 import { logger } from 'hono/logger';
 import { config } from './config.js';
 import { initDatabase, closeDatabase } from './storage/db.js';
+import { initVideoStorage } from './storage/video.js';
 import { pages } from './routes/pages.js';
 import { render } from './routes/render.js';
 import { agent } from './routes/agent.js';
@@ -153,6 +154,10 @@ async function main() {
     initDatabase();
     console.log(`Database initialized at ${config.lmdbPath}`);
 
+    console.log('Initializing video storage...');
+    initVideoStorage();
+    console.log(`Video storage initialized at ${config.videoStoragePath}`);
+
     console.log('Initializing analytics...');
     initAnalytics();
 
@@ -191,6 +196,7 @@ Endpoints:
   GET  /p/{id}/raw              - Fetch raw HTML
   GET  /p/{id}/md               - Fetch markdown source
   GET  /p/{id}/image            - Fetch image content
+  GET  /p/{id}/video            - Stream video content (with Range support)
   GET  /{path} (subdomain)      - Render subdomain page
   GET  /api/agent               - Agent instructions (markdown)
   POST /api/proxy               - Proxy external requests (CORS bypass)

--- a/src/routes/pages.ts
+++ b/src/routes/pages.ts
@@ -8,6 +8,7 @@ import { validateSubdomainName } from './subdomains.js';
 import { trackApiCall, trackPageCreated } from '../analytics/posthog.js';
 import { checkAuthRateLimit, recordFailedAttempt, resetAuthAttempts } from '../middleware/authRateLimit.js';
 import { deletePage as deletePageFromDb } from '../storage/db.js';
+import { saveVideo, deleteVideo } from '../storage/video.js';
 
 const pages = new Hono();
 
@@ -15,6 +16,7 @@ interface CreatePageBody {
   html?: string;
   markdown?: string;
   image?: string;
+  video?: string;  // Base64-encoded video data
   encoding?: 'utf-8' | 'base64';
   markdown_encoding?: 'utf-8' | 'base64';
   content_type?: string;
@@ -136,8 +138,15 @@ pages.post('/:id', async (c) => {
   // Image is stored as base64 (validated already)
   const imageData = body.image;
 
+  // Handle video: decode base64 and save to filesystem
+  let videoPath: string | undefined;
+  if (body.video) {
+    const videoBuffer = Buffer.from(body.video, 'base64');
+    videoPath = await saveVideo(id, videoBuffer, body.content_type || 'video/mp4', subdomain);
+  }
+
   // Generate ETag from combined content
-  const etagContent = (decodedHtml || '') + (decodedMarkdown || '') + (imageData || '');
+  const etagContent = (decodedHtml || '') + (decodedMarkdown || '') + (imageData || '') + (videoPath || '');
   const etag = generateEtag(etagContent);
 
   // Process auth if provided
@@ -165,6 +174,7 @@ pages.post('/:id', async (c) => {
       html: decodedHtml,
       markdown: decodedMarkdown,
       image: imageData,
+      video: videoPath,
       encoding: 'utf-8',
       content_type: body.content_type,
       title: body.title,
@@ -231,6 +241,24 @@ pages.post('/:id', async (c) => {
     }
   }
 
+  // Add image URL if image was provided
+  if (page.image) {
+    if (subdomain) {
+      response.image_url = `${pageUrl}/image`;
+    } else {
+      response.image_url = `${baseUrl}/p/${page.id}/image`;
+    }
+  }
+
+  // Add video URL if video was provided
+  if (page.video) {
+    if (subdomain) {
+      response.video_url = `${pageUrl}/video`;
+    } else {
+      response.video_url = `${baseUrl}/p/${page.id}/video`;
+    }
+  }
+
   // Track page creation
   if (created) {
     trackPageCreated({
@@ -239,6 +267,7 @@ pages.post('/:id', async (c) => {
       contentType: page.content_type || 'text/html',
       hasMarkdown: !!page.markdown,
       hasImage: !!page.image,
+      hasVideo: !!page.video,
     });
   }
 
@@ -293,6 +322,11 @@ pages.delete('/:id', async (c) => {
   const deleted = await deletePageFromDb(id, subdomain);
   if (!deleted) {
     return c.json({ error: 'Failed to delete page' }, 500);
+  }
+
+  // Delete video file if exists
+  if (page.video) {
+    await deleteVideo(page.video);
   }
 
   // Decrement subdomain page count if applicable

--- a/src/routes/render.ts
+++ b/src/routes/render.ts
@@ -5,6 +5,7 @@ import { generateEtag, etagMatches } from '../utils/etag.js';
 import { verifyPassword, verifyUrlToken, parseBasicAuth } from '../utils/auth.js';
 import { checkAuthRateLimit, recordFailedAttempt, resetAuthAttempts } from '../middleware/authRateLimit.js';
 import { trackPageView } from '../analytics/posthog.js';
+import { videoExists, getVideoPath, getVideoStats, createVideoStream, getVideoMimeType } from '../storage/video.js';
 import type { Page } from '../storage/db.js';
 
 const render = new Hono();
@@ -329,6 +330,104 @@ render.get('/:id/raw', async (c) => {
   });
 
   return c.body(page.html);
+});
+
+// GET /p/:id/video - Stream video with Range support
+render.get('/:id/video', async (c) => {
+  const id = c.req.param('id');
+
+  const idError = validateId(id);
+  if (idError) {
+    return c.json({ error: idError.message }, 400);
+  }
+
+  const page = getPage(id);
+  if (!page) {
+    return c.json({ error: 'Page not found' }, 404);
+  }
+
+  const authResponse = await verifyPageAuth(c, page);
+  if (authResponse) {
+    return authResponse;
+  }
+
+  if (!page.video) {
+    return c.json({ error: 'Page has no video content' }, 404);
+  }
+
+  // Check if video file exists
+  if (!videoExists(page.video)) {
+    return c.json({ error: 'Video file not found' }, 404);
+  }
+
+  // Get video stats for size
+  const stats = await getVideoStats(page.video);
+  if (!stats) {
+    return c.json({ error: 'Video file not found' }, 404);
+  }
+
+  const fileSize = stats.size;
+  const mimeType = getVideoMimeType(page.video);
+
+  // Handle Range request for video seeking
+  const range = c.req.header('Range');
+  
+  if (range) {
+    // Parse Range header (e.g., "bytes=0-1023")
+    const parts = range.replace(/bytes=/, '').split('-');
+    const start = parseInt(parts[0], 10);
+    const end = parts[1] ? parseInt(parts[1], 10) : fileSize - 1;
+    
+    // Validate range
+    if (start >= fileSize || end >= fileSize || start > end) {
+      return c.json({ error: 'Invalid range' }, 416);
+    }
+
+    const chunkSize = end - start + 1;
+    const stream = createVideoStream(page.video, { start, end });
+
+    if (!stream) {
+      return c.json({ error: 'Failed to stream video' }, 500);
+    }
+
+    c.header('Content-Type', mimeType);
+    c.header('Content-Length', String(chunkSize));
+    c.header('Content-Range', `bytes ${start}-${end}/${fileSize}`);
+    c.header('Accept-Ranges', 'bytes');
+    c.header('Cache-Control', 'public, max-age=31536000'); // Cache videos for 1 year
+
+    // Track page view (video)
+    trackPageView({
+      pageId: id,
+      referrer: c.req.header('Referer'),
+      userAgent: c.req.header('User-Agent'),
+      ip: c.req.header('X-Forwarded-For') || c.req.header('X-Real-IP'),
+    });
+
+    return new Response(stream as any, { status: 206 });
+  }
+
+  // Full file request (no Range header)
+  const stream = createVideoStream(page.video);
+  
+  if (!stream) {
+    return c.json({ error: 'Failed to stream video' }, 500);
+  }
+
+  c.header('Content-Type', mimeType);
+  c.header('Content-Length', String(fileSize));
+  c.header('Accept-Ranges', 'bytes');
+  c.header('Cache-Control', 'public, max-age=31536000'); // Cache videos for 1 year
+
+  // Track page view (video)
+  trackPageView({
+    pageId: id,
+    referrer: c.req.header('Referer'),
+    userAgent: c.req.header('User-Agent'),
+    ip: c.req.header('X-Forwarded-For') || c.req.header('X-Real-IP'),
+  });
+
+  return new Response(stream as any);
 });
 
 export { render };

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -10,17 +10,18 @@ export interface PageAuth {
 // Page data model
 export interface Page {
   id: string;
-  subdomain?: string;      // NEW: which subdomain owns this page
+  subdomain?: string;      // which subdomain owns this page
   html: string;
   markdown?: string;
-  image?: string;          // Base64-encoded image data
+  image?: string;           // Base64-encoded image data
+  video?: string;          // Path to video file on disk (relative to videoStoragePath)
   encoding: 'utf-8' | 'base64';
   content_type: string;
   title?: string;
   etag: string;
   created_at: string;
   updated_at: string;
-  auth?: PageAuth;  // Optional - undefined means public page
+  auth?: PageAuth;         // Optional - undefined means public page
 }
 
 // Subdomain data model
@@ -86,6 +87,7 @@ export async function savePage(
     html?: string;
     markdown?: string;
     image?: string;
+    video?: string;           // Path to video file on disk (relative)
     encoding?: 'utf-8' | 'base64';
     content_type?: string;
     title?: string;
@@ -107,6 +109,7 @@ export async function savePage(
     html: data.html || '',
     markdown: data.markdown,
     image: data.image,
+    video: data.video,
     encoding: data.encoding || 'utf-8',
     content_type: data.content_type || 'text/html; charset=utf-8',
     title: data.title,

--- a/src/storage/video.ts
+++ b/src/storage/video.ts
@@ -1,0 +1,149 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import { config } from '../config.js';
+
+/**
+ * Video storage module
+ * 
+ * Videos are stored on the filesystem with a reference in LMDB.
+ * File naming: {videoStoragePath}/{subdomain}/{id}.{ext}
+ * - For subdomain pages: {videoStoragePath}/{subdomain}/{id}.{ext}
+ * - For regular pages: {videoStoragePath}/{id}.{ext}
+ */
+
+/**
+ * Ensure the video storage directory exists
+ */
+export function initVideoStorage(): void {
+  if (!fs.existsSync(config.videoStoragePath)) {
+    fs.mkdirSync(config.videoStoragePath, { recursive: true });
+  }
+}
+
+/**
+ * Get the file extension for a content type
+ */
+function getExtension(contentType: string): string {
+  const extensions: Record<string, string> = {
+    'video/mp4': 'mp4',
+    'video/webm': 'webm',
+    'video/ogg': 'ogv',
+    'video/quicktime': 'mov',
+    'video/x-msvideo': 'avi',
+  };
+  return extensions[contentType] || 'mp4';
+}
+
+/**
+ * Generate a unique filename for a video
+ */
+function generateFilename(subdomain: string | undefined, id: string, contentType: string): string {
+  const ext = getExtension(contentType);
+  if (subdomain) {
+    return path.join(config.videoStoragePath, subdomain, `${id}.${ext}`);
+  }
+  return path.join(config.videoStoragePath, `${id}.${ext}`);
+}
+
+/**
+ * Save a video to persistent storage
+ * Returns the relative path to the video file
+ */
+export async function saveVideo(
+  id: string,
+  videoData: Buffer,
+  contentType: string,
+  subdomain?: string
+): Promise<string> {
+  // Ensure directory exists
+  if (subdomain) {
+    const subdir = path.join(config.videoStoragePath, subdomain);
+    if (!fs.existsSync(subdir)) {
+      fs.mkdirSync(subdir, { recursive: true });
+    }
+  } else {
+    initVideoStorage();
+  }
+
+  // Generate filename
+  const filename = generateFilename(subdomain, id, contentType);
+  
+  // Write video to disk
+  await fs.promises.writeFile(filename, videoData);
+  
+  // Return relative path (for storage in LMDB)
+  if (subdomain) {
+    return `${subdomain}/${id}.${getExtension(contentType)}`;
+  }
+  return `${id}.${getExtension(contentType)}`;
+}
+
+/**
+ * Get the full path to a video file
+ */
+export function getVideoPath(relativePath: string): string {
+  return path.join(config.videoStoragePath, relativePath);
+}
+
+/**
+ * Check if a video file exists
+ */
+export function videoExists(relativePath: string): boolean {
+  const fullPath = getVideoPath(relativePath);
+  return fs.existsSync(fullPath);
+}
+
+/**
+ * Get video file stats (size, etc.)
+ */
+export async function getVideoStats(relativePath: string): Promise<fs.Stats | null> {
+  const fullPath = getVideoPath(relativePath);
+  if (!fs.existsSync(fullPath)) {
+    return null;
+  }
+  return fs.promises.stat(fullPath);
+}
+
+/**
+ * Delete a video file
+ */
+export async function deleteVideo(relativePath: string): Promise<boolean> {
+  const fullPath = getVideoPath(relativePath);
+  if (fs.existsSync(fullPath)) {
+    await fs.promises.unlink(fullPath);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Create a read stream for a video file (for Range requests)
+ */
+export function createVideoStream(relativePath: string, options?: { start?: number; end?: number }): fs.ReadStream | null {
+  const fullPath = getVideoPath(relativePath);
+  if (!fs.existsSync(fullPath)) {
+    return null;
+  }
+  
+  if (options?.start !== undefined && options?.end !== undefined) {
+    return fs.createReadStream(fullPath, { start: options.start, end: options.end });
+  }
+  
+  return fs.createReadStream(fullPath);
+}
+
+/**
+ * Get MIME type from file extension
+ */
+export function getVideoMimeType(relativePath: string): string {
+  const ext = path.extname(relativePath).toLowerCase();
+  const mimeTypes: Record<string, string> = {
+    '.mp4': 'video/mp4',
+    '.webm': 'video/webm',
+    '.ogv': 'video/ogg',
+    '.mov': 'video/quicktime',
+    '.avi': 'video/x-msvideo',
+  };
+  return mimeTypes[ext] || 'video/mp4';
+}

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -102,13 +102,33 @@ export function validatePageBody(body: unknown): ValidationError | null {
     }
   }
 
-  // At least one of html, markdown, or image must be provided
-  if (!data.html && !data.markdown && !data.image) {
-    return { field: 'body', message: 'At least one of html, markdown, or image is required' };
+  // Validate video field if provided
+  let videoSize = 0;
+  if (data.video !== undefined) {
+    if (typeof data.video !== 'string') {
+      return { field: 'video', message: 'video must be a base64-encoded string' };
+    }
+    try {
+      const decoded = Buffer.from(data.video as string, 'base64');
+      videoSize = decoded.length;
+    } catch {
+      return { field: 'video', message: 'Invalid base64 encoding for video' };
+    }
+    if (videoSize > config.maxVideoSize) {
+      return { 
+        field: 'video', 
+        message: `Video size exceeds maximum of ${config.maxVideoSize} bytes (${Math.round(config.maxVideoSize / 1024 / 1024)}MB)` 
+      };
+    }
+  }
+
+  // At least one of html, markdown, image, or video must be provided
+  if (!data.html && !data.markdown && !data.image && !data.video) {
+    return { field: 'body', message: 'At least one of html, markdown, image, or video is required' };
   }
 
   // For image-only pages, validate content_type is an image type
-  const isImagePage = data.image && !data.html && !data.markdown;
+  const isImagePage = data.image && !data.html && !data.markdown && !data.video;
   if (isImagePage) {
     const contentType = data.content_type as string | undefined;
     if (!contentType) {
@@ -121,6 +141,24 @@ export function validatePageBody(body: unknown): ValidationError | null {
       return { 
         field: 'content_type', 
         message: `content_type must be one of: ${config.allowedImageTypes.join(', ')}` 
+      };
+    }
+  }
+
+  // For video-only pages, validate content_type is a video type
+  const isVideoPage = data.video && !data.html && !data.markdown && !data.image;
+  if (isVideoPage) {
+    const contentType = data.content_type as string | undefined;
+    if (!contentType) {
+      return { field: 'content_type', message: 'content_type is required for video pages' };
+    }
+    if (typeof contentType !== 'string') {
+      return { field: 'content_type', message: 'content_type must be a string' };
+    }
+    if (!(config.allowedVideoTypes as readonly string[]).includes(contentType)) {
+      return { 
+        field: 'content_type', 
+        message: `content_type must be one of: ${config.allowedVideoTypes.join(', ')}` 
       };
     }
   }


### PR DESCRIPTION
## Summary

Adds video support to zenbin with persistent filesystem storage.

### Key Changes

- **Videos stored on disk**, not in LMDB (just path reference stored)
- **100MB max video size** (configurable via `MAX_VIDEO_SIZE`)
- **Range request support** for video seeking/streaming
- **Supported formats**: mp4, webm, ogg, mov, avi

### New Configuration

```bash
VIDEO_STORAGE_PATH=./data/videos    # Where videos are stored
MAX_VIDEO_SIZE=104857600            # 100MB default
```

### API Changes

- `POST /v1/pages/{id}` now accepts `video` field (base64-encoded)
- `GET /p/{id}/video` streams video with Range support
- Response includes `video_url` when video is present

### Storage Structure

```
data/
├── zenbin.lmdb/           # LMDB for metadata
└── videos/                # Video files
    ├── {page-id}.mp4      # Root-level pages
    └── {subdomain}/       # Subdomain videos
        └── {page-id}.mp4
```

### Files Changed

- `src/config.ts` — Add video config (maxVideoSize, videoStoragePath, allowedVideoTypes)
- `src/storage/db.ts` — Add `video?: string` to Page interface
- `src/storage/video.ts` — New module for video file operations
- `src/routes/pages.ts` — Handle video upload/delete
- `src/routes/render.ts` — Add `/p/{id}/video` streaming endpoint
- `src/utils/validation.ts` — Validate video size/type
- `src/index.ts` — Initialize video storage on startup

### Testing

```bash
# Upload a video
curl -X POST http://localhost:3000/v1/pages/my-video \
  -H 'Content-Type: application/json' \
  -d '{
    "video": "<base64-encoded-video>",
    "content_type": "video/mp4"
  }'

# Stream the video
curl http://localhost:3000/p/my-video/video

# With Range request (for seeking)
curl -H 'Range: bytes=0-1023' http://localhost:3000/p/my-video/video
```