### PR TITLE
fix: redirect video-only pages from /p/:id to /p/:id/video

### DIFF
--- a/src/routes/render.ts
+++ b/src/routes/render.ts
@@ -169,6 +169,11 @@ render.get('/:id', async (c) => {
     return c.body(imageBuffer);
   }
 
+  // If page has video but no HTML, redirect to the video endpoint
+  if (page.video && !page.html) {
+    return c.redirect(`/p/${id}/video`, 302);
+  }
+
   // Check If-None-Match for caching HTML
   const ifNoneMatch = c.req.header('If-None-Match');
   if (etagMatches(ifNoneMatch, page.etag)) {


### PR DESCRIPTION
## Summary

- When a page has `page.video` set but `page.html` is empty, `GET /p/:id` was falling through to `c.body('')` with `text/plain` content type, so browsers could not play the video.
- Added a video-only redirect that mirrors the existing image-only pattern: if a page has video but no HTML, redirect 302 to `/p/:id/video` which already streams with the correct Content-Type.

## Test plan

- All 112 existing tests pass with no changes needed.
- Manually verify that visiting `/p/:id` for a video-only page now redirects to `/p/:id/video`.