### PR TITLE
fix: rotate JWT secret and admin token out of public config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,14 @@ BASE_URL=http://localhost:3000
 # Storage
 LMDB_PATH=./data/zenbin.lmdb
 
+# Auth
+# Required for JWT-based API key verification (legacy path).
+# Primary auth is Ed25519 signed requests — this is only needed for portal-issued keys.
+ZENBIN_JWT_SECRET=
+
+# Admin API access token
+ADMIN_TOKEN=dev-admin-token
+
 # Limits
 MAX_PAYLOAD_SIZE=524288
 MAX_ID_LENGTH=128

--- a/render.yaml
+++ b/render.yaml
@@ -27,7 +27,9 @@ services:
       - key: RATE_LIMIT_MAX_REQUESTS
         value: 100
       - key: ZENBIN_JWT_SECRET
-        value: change-me-in-production
+        sync: false
+      - key: ADMIN_TOKEN
+        sync: false
       - key: SUBDOMAIN_BASE_DOMAIN
         value: zenbin.org
     disk:

--- a/src/config.ts
+++ b/src/config.ts
@@ -64,8 +64,10 @@ export const config = {
     nonceTtlMs: parseInt(process.env.SIGNED_PUBLISHING_NONCE_TTL_MS || '300000', 10),
   },
 
-  admin: {
-    token: process.env.ADMIN_TOKEN || 'dev-admin-token',
+  get admin() {
+    return {
+      token: process.env.ADMIN_TOKEN || '',
+    };
   },
 
   // Analytics

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,6 +186,14 @@ async function main() {
     console.log('Initializing analytics...');
     initAnalytics();
 
+    // Security warnings for missing secrets
+    if (!process.env.ZENBIN_JWT_SECRET) {
+      console.warn('[ZenBin] WARNING: ZENBIN_JWT_SECRET is not set. JWT-based API key verification is disabled.');
+    }
+    if (!process.env.ADMIN_TOKEN) {
+      console.warn('[ZenBin] WARNING: ADMIN_TOKEN is not set. Admin API routes are disabled.');
+    }
+
     const server = serve({
       fetch: app.fetch,
       port: config.port,

--- a/src/middleware/verifyApiKey.ts
+++ b/src/middleware/verifyApiKey.ts
@@ -5,8 +5,11 @@ import { Context, Next } from 'hono';
 import jwt from 'jsonwebtoken';
 import { config } from '../config.js';
 
-// Environment variable - must match portal's ZENBIN_JWT_SECRET
-const ZENBIN_JWT_SECRET = process.env.ZENBIN_JWT_SECRET || 'change-me-in-production';
+// JWT secret must be configured via ZENBIN_JWT_SECRET environment variable.
+// If not set, JWT-based API key verification is disabled and requests fall through
+// to the free tier handler. This is intentional — the primary auth model is
+// Ed25519 signed requests, not JWT.
+const ZENBIN_JWT_SECRET = process.env.ZENBIN_JWT_SECRET || '';
 
 // In-memory usage tracking (replace with Redis for production)
 const freeUsage = new Map<string, { count: number; resetTime: number }>();

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -20,6 +20,7 @@ beforeAll(() => {
   // Set test database path
   process.env.LMDB_PATH = TEST_DB_PATH;
   process.env.VIDEO_STORAGE_PATH = TEST_VIDEO_PATH;
+  process.env.ADMIN_TOKEN = 'test-admin-token';
 
   try {
     rmSync(TEST_VIDEO_PATH, { recursive: true, force: true });


### PR DESCRIPTION
## Fixes #10

### Changes

- **render.yaml**: `ZENBIN_JWT_SECRET` and `ADMIN_TOKEN` changed from hardcoded values to `sync: false` (managed via Render dashboard)
- **verifyApiKey.ts**: Removed `|| 'change-me-in-production'` fallback — JWT verification is disabled when secret is not set
- **config.ts**: Removed `|| 'dev-admin-token'` fallback — admin routes are disabled when token is not set. Made `admin` a getter so env vars are read at access time.
- **index.ts**: Added startup warnings when secrets are not configured
- **.env.example**: Added `ZENBIN_JWT_SECRET` and `ADMIN_TOKEN` documentation
- **test/setup.ts**: Set `ADMIN_TOKEN` in test environment

### Bonus: Also fixed ADMIN_TOKEN

During the audit (Phase 4), I found that `ADMIN_TOKEN` had the same hardcoded fallback pattern (`dev-admin-token`). Fixed it the same way.

### Verification

- ✅ All 149 tests pass
- ✅ Typecheck clean
- ✅ Build clean
- ✅ No hardcoded secrets in source or config
- ✅ Startup warns when secrets are missing
- ✅ Without secrets, JWT auth and admin routes are disabled (by design)

### Post-merge action required

⚠️ **You must set `ZENBIN_JWT_SECRET` and `ADMIN_TOKEN` in the Render dashboard** before or immediately after merging. Otherwise:
- JWT-based API key verification will be disabled (free tier still works)
- Admin API routes (`/v1/admin/keys/*`) will return 401

This is intentional — the primary auth model is Ed25519 signed requests.