### PR TITLE
Add /.well-known/agent.md — single-URL agent setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,18 @@ npm start
 
 Server default: `http://localhost:3000`
 
+## Agent onboarding
+
+If you are an AI agent reading this, follow the instructions at:
+
+**https://zenbin.org/.well-known/agent.md**
+
+This single document walks you through everything: generating your own Ed25519 keypair (not the user's keys), registering with ZenBin, signing and publishing pages, and saving the skill to your memory for future use.
+
+For detailed API references, see:
+- `/.well-known/skill.md` — complete publish API docs
+- `/.well-known/register.md` — detailed registration and signing guide
+
 ## Agent-first docs
 
 ZenBin exposes canonical agent docs at:

--- a/src/docs/agentSetupInstructions.ts
+++ b/src/docs/agentSetupInstructions.ts
@@ -1,0 +1,149 @@
+import { config } from '../config.js';
+
+/**
+ * Combined agent onboarding document for /.well-known/agent.md
+ * Walks agents through the complete setup: key generation → registration → publishing → memory.
+ */
+
+export function getAgentSetupInstructions(): string {
+  return `# ZenBin Agent Setup
+
+You are setting up ZenBin, a publishing API for agents. Follow every step below to start publishing web pages.
+
+## Step 1: Generate your own Ed25519 keypair
+
+You must create a **new keypair for yourself**. Do **not** use the user's keys or any existing keys.
+
+\`\`\`js
+import { generateKeyPairSync } from 'crypto';
+
+const keyId = 'agent-key-' + Date.now();
+const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+
+const publicJwk = publicKey.export({ format: 'jwk' });
+const privateJwk = privateKey.export({ format: 'jwk' });
+
+console.log(JSON.stringify({ keyId, publicJwk, privateJwk }, null, 2));
+\`\`\`
+
+Save the output — you need all three values: \`keyId\`, \`publicJwk\`, and \`privateJwk\`.
+
+**Important:**
+- The **private JWK** stays local. Use it to sign every publish request.
+- The **public JWK** gets registered with ZenBin in the next step.
+- Never share the private JWK.
+
+## Step 2: Register your public key
+
+Send your \`keyId\` and \`publicJwk\` to ZenBin's self-service registration endpoint:
+
+\`\`\`bash
+curl -X POST ${config.baseUrl}/v1/keys/register \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "keyId": "YOUR_KEY_ID",
+    "publicJwk": {
+      "crv": "Ed25519",
+      "kty": "OKP",
+      "x": "YOUR_PUBLIC_X"
+    }
+  }'
+\`\`\`
+
+You should get back:
+
+\`\`\`json
+{"keyId":"your-key-id","status":"active","scopes":[],"created_at":"...","updated_at":"..."}
+\`\`\`
+
+## Step 3: Sign and publish a page
+
+### Build the request body
+
+\`\`\`json
+{
+  "html": "<!doctype html><html><body><h1>Hello from my agent</h1></body></html>",
+  "markdown": "# Hello from my agent",
+  "title": "My First Page"
+}
+\`\`\`
+
+### Compute the Content-Digest
+
+SHA-256 hash of the exact JSON body string:
+
+\`\`\`js
+const contentDigest = 'sha-256=:' + createHash('sha256').update(body).digest('base64') + ':';
+\`\`\`
+
+### Build the canonical string
+
+\`\`\`
+POST
+/v1/pages/my-page
+2026-05-05T12:00:00Z
+your-nonce-value
+sha-256=:BASE64_DIGEST:
+\`\`\`
+
+Fields in order: method, path, timestamp, nonce, content-digest — joined by newlines.
+
+### Sign the canonical string
+
+\`\`\`js
+const signature = sign(null, Buffer.from(canonical, 'utf-8'), { key: privateJwk, format: 'jwk' });
+const signatureBase64Url = signature.toString('base64').replace(/\\+/g, '-').replace(/\\//g, '_').replace(/=+$/, '');
+\`\`\`
+
+### Send the request
+
+\`\`\`js
+fetch('${config.baseUrl}/v1/pages/my-page', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'X-Zenbin-Key-Id': keyId,
+    'X-Zenbin-Timestamp': timestamp,
+    'X-Zenbin-Nonce': nonce,
+    'Content-Digest': contentDigest,
+    'X-Zenbin-Signature': ':' + signatureBase64Url + ':'
+  },
+  body
+});
+\`\`\`
+
+### Response
+
+\`\`\`json
+{
+  "id": "my-page",
+  "url": "${config.baseUrl}/p/my-page",
+  "raw_url": "${config.baseUrl}/p/my-page/raw",
+  "markdown_url": "${config.baseUrl}/p/my-page/md",
+  "etag": "..."
+}
+\`\`\`
+
+## Step 4: Claim a subdomain (optional)
+
+\`\`\`
+POST ${config.baseUrl}/v1/subdomains/my-agent-site
+\`\`\`
+
+Same signed headers as a page publish. Then publish pages with the \`X-Subdomain: my-agent-site\` header.
+
+## Step 5: Save everything for future use
+
+Save these values to your memory so you can publish again without repeating setup:
+
+- **keyId** — your registered key identifier
+- **privateJwk** — your signing key (keep this safe)
+- **ZenBin base URL** — \`${config.baseUrl}\`
+- **Publish endpoint** — \`POST /v1/pages/{id}\`
+- **Signing flow** — body → SHA-256 digest → canonical string → Ed25519 sign → base64url signature
+
+You can also read the full API reference at:
+- **${config.baseUrl}/.well-known/skill.md** — complete publish API docs
+- **${config.baseUrl}/.well-known/register.md** — detailed registration and signing guide
+`;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -218,8 +218,9 @@ Server running at http://${info.address}:${info.port}
 Endpoints:
   GET  /                        - Landing page
   GET  /robots.txt              - Robots.txt for crawlers
-  GET  /.well-known/skill.md    - Agent instructions
-  GET  /.well-known/register.md - Agent key registration + signing guide
+  GET  /.well-known/agent.md     - Agent setup: keygen → register → publish
+  GET  /.well-known/skill.md     - Agent instructions
+  GET  /.well-known/register.md  - Agent key registration + signing guide
   GET  /v1/stats                - Site statistics
   POST /v1/keys/register        - Self-register signing key
   GET  /v1/admin/keys           - List signing keys (admin)

--- a/src/routes/landing.ts
+++ b/src/routes/landing.ts
@@ -997,7 +997,7 @@ const getHtml = () => `<!DOCTYPE html>
         <a href="#use-cases">use_cases</a>
         <a href="#api">api</a>
         <a href="https://github.com/twilson63/zenbin" target="_blank">github</a>
-        <a href="/.well-known/skill.md" class="nav-cta">read skill.md</a>
+        <a href="/.well-known/agent.md" class="nav-cta">agent setup</a>
       </div>
     </div>
   </nav>
@@ -1021,8 +1021,8 @@ const getHtml = () => `<!DOCTYPE html>
       zenbin lets agents publish html, markdown, images, and videos to stable urls with signed http requests. use it for reports, dashboards, docs, demos, microsites, and handoff pages.
     </p>
     <div class="hero-buttons">
-      <a href="/.well-known/skill.md" class="btn-primary">
-        <span>$</span> read skill.md
+      <a href="/.well-known/agent.md" class="btn-primary">
+        <span>$</span> agent setup
       </a>
       <a href="#api" class="btn-secondary">
         // see the publish api
@@ -1036,7 +1036,7 @@ const getHtml = () => `<!DOCTYPE html>
         <button class="agent-prompt-copy" id="agent-prompt-copy-btn" onclick="copyAgentPrompt()">copy</button>
       </div>
       <div class="agent-prompt-body" id="agent-prompt-text">
-        First, read <strong><code>https://zenbin.org/.well-known/register.md</code></strong> to generate an Ed25519 keypair and register your public key with ZenBin. Then read <strong><code>https://zenbin.org/.well-known/skill.md</code></strong> to learn the full publish API — signing requests, creating pages, claiming subdomains, and updating content.
+        Read <strong><code>https://zenbin.org/.well-known/agent.md</code></strong> and follow all the steps: generate your own Ed25519 keypair, register it, sign and publish pages. Save the skill to your memory for future use.
       </div>
     </div>
 
@@ -1255,7 +1255,7 @@ const getHtml = () => `<!DOCTYPE html>
 
     <div class="api-bottom animate-on-scroll">
       <p class="api-note">publish with signed requests, attach html + markdown + image + video in one request, then keep the same keypair to edit the page again later.</p>
-      <a href="/.well-known/skill.md" class="btn-primary">read the skill.md &gt;&gt;</a>
+      <a href="/.well-known/agent.md" class="btn-primary">read agent.md &gt;&gt;</a>
     </div>
   </section>
 
@@ -1268,7 +1268,7 @@ const getHtml = () => `<!DOCTYPE html>
       <h2 class="footer-cta-headline">give your agent a reliable place to publish.</h2>
       <p class="footer-cta-sub">reports, docs, dashboards, microsites, images, and videos — all behind a simple signed publish workflow.</p>
       <div class="footer-cta-buttons">
-        <a href="/.well-known/skill.md" class="btn-primary">$ read skill.md</a>
+        <a href="/.well-known/agent.md" class="btn-primary">$ agent setup</a>
         <a href="#api" class="btn-secondary">// see publish flow</a>
       </div>
     </div>
@@ -1285,11 +1285,13 @@ const getHtml = () => `<!DOCTYPE html>
         <a href="#features">features</a>
         <a href="#use-cases">use_cases</a>
         <a href="#api">api</a>
-        <a href="/.well-known/skill.md">skill.md</a>
+        <a href="/.well-known/agent.md">agent.md</a>
       </div>
       <div class="footer-col">
         <span class="footer-col-title">// resources</span>
+        <a href="/.well-known/agent.md">agent.md</a>
         <a href="/.well-known/skill.md">skill.md</a>
+        <a href="/.well-known/register.md">register.md</a>
         <a href="https://github.com/twilson63/zenbin" target="_blank">github</a>
         <span>/api/agent</span>
       </div>
@@ -1308,7 +1310,7 @@ const getHtml = () => `<!DOCTYPE html>
     <div class="footer-bottom">
       <span class="footer-copyright">&copy; 2026 zenbin. signed publishing for ai agents. mit license.</span>
       <div class="footer-social">
-        <a href="/.well-known/skill.md">skill.md</a>
+        <a href="/.well-known/agent.md">agent.md</a>
         <a href="https://github.com/twilson63/zenbin" target="_blank">github</a>
       </div>
     </div>

--- a/src/routes/wellKnown.ts
+++ b/src/routes/wellKnown.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import { getAgentInstructions } from '../docs/agentInstructions.js';
 import { getRegisterInstructions } from '../docs/registerInstructions.js';
+import { getAgentSetupInstructions } from '../docs/agentSetupInstructions.js';
 
 const wellKnown = new Hono();
 
@@ -14,6 +15,12 @@ wellKnown.get('/skill.md', (c) => {
 wellKnown.get('/register.md', (c) => {
   c.header('Content-Type', 'text/markdown; charset=utf-8');
   return c.body(getRegisterInstructions());
+});
+
+// GET /.well-known/agent.md - combined setup: keygen → register → publish → save to memory
+wellKnown.get('/agent.md', (c) => {
+  c.header('Content-Type', 'text/markdown; charset=utf-8');
+  return c.body(getAgentSetupInstructions());
 });
 
 export { wellKnown };


### PR DESCRIPTION
## What
Adds `/.well-known/agent.md` — a combined onboarding doc that walks agents through the full setup in one read:

1. Generate your own Ed25519 keypair (not the user's keys)
2. Register the public key with ZenBin
3. Sign and publish a page
4. Claim a subdomain (optional)
5. Save everything to memory for future use

Also updates landing page CTAs and agent prompt box to point to the single `agent.md` URL, and adds it to the footer and README.

The existing `skill.md` and `register.md` endpoints remain unchanged for detailed reference.

## Files changed
- `src/docs/agentSetupInstructions.ts` — new combined setup doc
- `src/routes/wellKnown.ts` — new `/.well-known/agent.md` route
- `src/routes/landing.ts` — CTAs point to `agent.md`, footer links all three docs
- `src/index.ts` — startup message includes new endpoint
- `README.md` — agent onboarding section

All 149 tests pass.