### PR TITLE
Add provenance verification for signed publishes

### DIFF
--- a/PROVENANCE-PLAN.md
+++ b/PROVENANCE-PLAN.md
@@ -1,0 +1,54 @@
+# Content Provenance Verification — TDD Implementation Plan
+
+## Issue
+GitHub #21 — Cryptographic provenance verification for published content
+
+## Goal
+When an agent publishes a page, the signature and public key are stored and exposed on reads, so any consumer can verify who created it.
+
+## Design Decisions
+- Store `publishSignature` and `contentDigest` on the `Page` record (both are already computed at publish time — just persist them)
+- Add `GET /v1/keys/:keyId/jwk` endpoint to expose public keys
+- Add provenance fields to page read responses (JSON and HTML metadata)
+- Add `POST /v1/verify` endpoint for programmatic verification
+- All new fields are optional — existing pages without signatures still work fine
+- No billing interaction — verification is free for all plans
+
+## Phases
+
+### Phase 0: Types & Storage
+- [ ] Add `publishSignature` and `contentDigest` to `Page` type in `src/types.ts`
+- [ ] Update `savePage` in `src/storage/db.ts` to persist these fields
+- [ ] Write tests for new Page fields (backward compat — undefined values)
+
+### Phase 1: Persist Signature on Publish
+- [ ] In `src/routes/pages.ts` POST handler, capture `X-Zenbin-Signature` and `Content-Digest` headers
+- [ ] Pass them to `savePage` so they're stored on the page record
+- [ ] Include `signature`, `contentDigest`, `keyId`, and `verificationUrl` in the publish response JSON
+- [ ] Write tests: published pages should have signature and contentDigest in response
+
+### Phase 2: Expose Public Keys
+- [ ] Add `GET /v1/keys/:keyId/jwk` endpoint that returns the public JWK for a key
+- [ ] Write tests: returns 200 with JWK for valid keyId, 404 for unknown keyId
+
+### Phase 3: Provenance on Read
+- [ ] Add provenance fields to page read responses (JSON: `/p/:id` when `Accept: application/json`)
+- [ ] Add `<meta>` tags to rendered HTML pages with signature and keyId
+- [ ] Write tests: GET page returns provenance fields
+
+### Phase 4: Verification Endpoint
+- [ ] Add `POST /v1/verify` endpoint that takes `keyId`, `content`, `signature`, and optionally `contentDigest`
+- [ ] Look up the public key, verify the signature against the content
+- [ ] Return `{ valid: boolean, keyId, verifiedAt }`
+- [ ] Write tests: valid signature, invalid signature, unknown keyId
+
+### Phase 5: Agent Documentation
+- [ ] Update `/.well-known/agent.md` with provenance documentation
+- [ ] Update `/.well-known/skill.md` with verification instructions
+- [ ] Add provenance section to README
+
+## Testing Strategy
+- All tests follow existing patterns in `src/test/`
+- New test file: `src/test/provenance.test.ts`
+- Existing tests must continue passing at every step
+- Test backward compatibility: pages published before provenance should still work without signature fields

--- a/PROVENANCE-PLAN.md
+++ b/PROVENANCE-PLAN.md
@@ -7,7 +7,7 @@ GitHub #21 — Cryptographic provenance verification for published content
 When an agent publishes a page, the signature and public key are stored and exposed on reads, so any consumer can verify who created it.
 
 ## Design Decisions
-- Store `publishSignature` and `contentDigest` on the `Page` record (both are already computed at publish time — just persist them)
+- Store `publishSignature`, `contentDigest`, `publishTimestamp`, `publishNonce`, `publishMethod`, and `publishPath` on the `Page` record
 - Add `GET /v1/keys/:keyId/jwk` endpoint to expose public keys
 - Add provenance fields to page read responses (JSON and HTML metadata)
 - Add `POST /v1/verify` endpoint for programmatic verification
@@ -17,35 +17,36 @@ When an agent publishes a page, the signature and public key are stored and expo
 ## Phases
 
 ### Phase 0: Types & Storage
-- [ ] Add `publishSignature` and `contentDigest` to `Page` type in `src/types.ts`
-- [ ] Update `savePage` in `src/storage/db.ts` to persist these fields
-- [ ] Write tests for new Page fields (backward compat — undefined values)
+- [x] Add provenance fields to the `Page` type in `src/storage/db.ts`
+- [x] Update `savePage` in `src/storage/db.ts` to persist these fields
+- [x] Write tests for signed publish/read verification
 
 ### Phase 1: Persist Signature on Publish
-- [ ] In `src/routes/pages.ts` POST handler, capture `X-Zenbin-Signature` and `Content-Digest` headers
-- [ ] Pass them to `savePage` so they're stored on the page record
-- [ ] Include `signature`, `contentDigest`, `keyId`, and `verificationUrl` in the publish response JSON
-- [ ] Write tests: published pages should have signature and contentDigest in response
+- [x] In `src/routes/pages.ts` POST handler, capture signature, digest, timestamp, nonce, method, and path
+- [x] Pass them to `savePage` so they're stored on the page record
+- [x] Include `signature`, `contentDigest`, `keyId`, `verificationUrl`, `keyUrl`, and canonical fields in the publish response JSON
+- [x] Write tests: published pages should have signature and contentDigest in response
 
 ### Phase 2: Expose Public Keys
-- [ ] Add `GET /v1/keys/:keyId/jwk` endpoint that returns the public JWK for a key
-- [ ] Write tests: returns 200 with JWK for valid keyId, 404 for unknown keyId
+- [x] Add `GET /v1/keys/:keyId/jwk` endpoint that returns the public JWK for a key
+- [x] Write tests: returns 200 with JWK for valid keyId, 404 for unknown keyId
 
 ### Phase 3: Provenance on Read
-- [ ] Add provenance fields to page read responses (JSON: `/p/:id` when `Accept: application/json`)
-- [ ] Add `<meta>` tags to rendered HTML pages with signature and keyId
-- [ ] Write tests: GET page returns provenance fields
+- [x] Add provenance fields to page read responses (JSON: `/p/:id` when `Accept: application/json`)
+- [x] Add `<meta>` tags and HTTP headers to rendered HTML pages with signature and keyId
+- [x] Write tests: GET page returns provenance fields
 
 ### Phase 4: Verification Endpoint
-- [ ] Add `POST /v1/verify` endpoint that takes `keyId`, `content`, `signature`, and optionally `contentDigest`
-- [ ] Look up the public key, verify the signature against the content
-- [ ] Return `{ valid: boolean, keyId, verifiedAt }`
-- [ ] Write tests: valid signature, invalid signature, unknown keyId
+- [x] Add `POST /v1/verify` endpoint that takes `keyId`, `content`, `signature`, `contentDigest`, timestamp, nonce, method, and path
+- [x] Look up the public key, verify digest and signature against the canonical request
+- [x] Return `{ valid: boolean, keyId, verifiedAt }`
+- [x] Write tests: signed publish smoke verifies locally and through `/v1/verify`
 
 ### Phase 5: Agent Documentation
-- [ ] Update `/.well-known/agent.md` with provenance documentation
-- [ ] Update `/.well-known/skill.md` with verification instructions
-- [ ] Add provenance section to README
+- [x] Update `/.well-known/agent.md` with provenance documentation
+- [x] Update `/.well-known/skill.md` with verification instructions
+- [x] Add provenance section to README
+- [x] Update installed ZenBin agent skill with artifact verification workflow
 
 ## Testing Strategy
 - All tests follow existing patterns in `src/test/`

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ ZenBin is built around a few simple ideas:
 ## Features
 
 - **Signed publishing** — Ed25519 request signing for agent-safe writes
+- **Content provenance verification** — Published pages expose signature metadata so readers can verify authorship and integrity
 - **HTML + Markdown together** — Store rendered HTML and source Markdown in one publish
 - **Independent encoding controls** — `encoding` for HTML, `markdown_encoding` for Markdown
 - **Image support** — Upload images up to 5MB as base64 and serve them directly
@@ -212,7 +213,16 @@ Standalone page:
   "url": "http://localhost:3000/p/my-page",
   "raw_url": "http://localhost:3000/p/my-page/raw",
   "markdown_url": "http://localhost:3000/p/my-page/md",
-  "etag": "\"abc123...\""
+  "etag": "\"abc123...\"",
+  "keyId": "agent-key-123",
+  "signature": ":BASE64URL_SIGNATURE:",
+  "contentDigest": "sha-256=:BASE64_DIGEST:",
+  "timestamp": "2026-03-22T18:10:00Z",
+  "nonce": "8f0f6e3d4d2042e9",
+  "signedMethod": "POST",
+  "signedPath": "/v1/pages/my-page",
+  "verificationUrl": "http://localhost:3000/v1/verify",
+  "keyUrl": "http://localhost:3000/v1/keys/agent-key-123/jwk"
 }
 ```
 
@@ -542,6 +552,72 @@ Subdomain video update flow:
 - save your private key, key id, subdomain name, and page id
 - re-run the same signed publish later to replace the video or page content
 
+## Content Provenance Verification
+
+Every signed publish stores the signature metadata needed to verify the original request body.
+
+### What readers get
+
+Rendered HTML responses include these headers when provenance is available:
+
+```http
+X-Zenbin-Key-Id: agent-key-123
+X-Zenbin-Signature: :BASE64URL_SIGNATURE:
+X-Zenbin-Content-Digest: sha-256=:BASE64_DIGEST:
+X-Zenbin-Timestamp: 2026-03-22T18:10:00Z
+X-Zenbin-Nonce: 8f0f6e3d4d2042e9
+X-Zenbin-Signed-Method: POST
+X-Zenbin-Signed-Path: /v1/pages/my-page
+```
+
+You can also request JSON metadata:
+
+```http
+GET /p/my-page
+Accept: application/json
+```
+
+### Verify through ZenBin
+
+```bash
+curl -X POST http://localhost:3000/v1/verify \
+  -H "Content-Type: application/json" \
+  -d '{
+    "keyId": "agent-key-123",
+    "content": "{\"html\":\"<h1>Hello</h1>\",\"title\":\"Hello\"}",
+    "signature": ":BASE64URL_SIGNATURE:",
+    "contentDigest": "sha-256=:BASE64_DIGEST:",
+    "timestamp": "2026-03-22T18:10:00Z",
+    "nonce": "8f0f6e3d4d2042e9",
+    "method": "POST",
+    "path": "/v1/pages/my-page"
+  }'
+```
+
+Success response:
+
+```json
+{ "valid": true, "keyId": "agent-key-123", "verifiedAt": "..." }
+```
+
+### Verify locally
+
+1. Fetch the public key from `GET /v1/keys/{keyId}/jwk`.
+2. Rebuild the canonical string:
+
+```text
+POST
+/v1/pages/my-page
+2026-03-22T18:10:00Z
+8f0f6e3d4d2042e9
+sha-256=:BASE64_DIGEST:
+```
+
+3. Verify `X-Zenbin-Signature` as an Ed25519 signature over that string.
+4. Hash the exact original publish JSON and compare it to `X-Zenbin-Content-Digest`.
+
+Important: provenance verifies the **original publish request body**, not the rendered HTML after ZenBin injects metadata or analytics.
+
 ## Viewer Authentication
 
 Pages are public by default.
@@ -639,6 +715,7 @@ Each example shows the same core flow:
 3. build the canonical signing string
 4. sign it with Ed25519
 5. `POST` it to ZenBin
+6. verify the resulting provenance through `/v1/verify`
 
 ## Development
 

--- a/examples/deno_publish.ts
+++ b/examples/deno_publish.ts
@@ -53,4 +53,22 @@ const response = await fetch(baseUrl + path, {
   body,
 });
 
-console.log(response.status, await response.text());
+const publishResult = await response.json();
+console.log(response.status, publishResult);
+
+// Provenance smoke check: verify the original publish body through ZenBin.
+const verifyResponse = await fetch(`${baseUrl}/v1/verify`, {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    keyId,
+    content: body,
+    signature: publishResult.signature,
+    contentDigest: publishResult.contentDigest,
+    timestamp,
+    nonce,
+    method: 'POST',
+    path,
+  }),
+});
+console.log('verification', await verifyResponse.json());

--- a/examples/node-publish.mjs
+++ b/examples/node-publish.mjs
@@ -47,4 +47,22 @@ const response = await fetch(baseUrl + path, {
   body,
 });
 
-console.log(response.status, await response.text());
+const publishResult = await response.json();
+console.log(response.status, publishResult);
+
+// Provenance smoke check: verify the original publish body through ZenBin.
+const verifyResponse = await fetch(`${baseUrl}/v1/verify`, {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    keyId,
+    content: body,
+    signature: publishResult.signature,
+    contentDigest: publishResult.contentDigest,
+    timestamp,
+    nonce,
+    method: 'POST',
+    path,
+  }),
+});
+console.log('verification', await verifyResponse.json());

--- a/examples/python_publish.py
+++ b/examples/python_publish.py
@@ -43,4 +43,22 @@ if subdomain:
     headers['X-Subdomain'] = subdomain
 
 response = requests.post(base_url + path, headers=headers, data=body)
-print(response.status_code, response.text)
+publish_result = response.json()
+print(response.status_code, publish_result)
+
+# Provenance smoke check: verify the original publish body through ZenBin.
+verify_response = requests.post(
+    base_url + '/v1/verify',
+    headers={'Content-Type': 'application/json'},
+    data=json.dumps({
+        'keyId': key_id,
+        'content': body,
+        'signature': publish_result['signature'],
+        'contentDigest': publish_result['contentDigest'],
+        'timestamp': timestamp,
+        'nonce': nonce,
+        'method': 'POST',
+        'path': path,
+    }),
+)
+print('verification', verify_response.json())

--- a/src/docs/agentInstructions.ts
+++ b/src/docs/agentInstructions.ts
@@ -18,6 +18,7 @@ import { config } from '../config.js';
  * - image and video payloads are always base64 strings.
  * - Page ownership is tied to the signing key that created the page.
  * - Re-publishing with the same key updates the same page immediately.
+ * - Published pages expose provenance headers that can be verified locally or with /v1/verify.
  */
 export function getAgentInstructions(): string {
   const baseUrl = config.baseUrl;
@@ -92,6 +93,7 @@ That means:
 - ZenBin stores the matching public key
 - the signing key that creates a page becomes that page's owner
 - the same signing key can update or delete that page later
+- ZenBin stores the publish signature metadata so readers can verify who signed the original content
 
 If you save your publish code and keep the same keypair, you can edit pages again later.
 
@@ -287,7 +289,16 @@ Videos are always base64 in the request body:
   "url": "${baseUrl}/p/my-page",
   "raw_url": "${baseUrl}/p/my-page/raw",
   "markdown_url": "${baseUrl}/p/my-page/md",
-  "etag": "\"...\""
+  "etag": "\"...\"",
+  "keyId": "agent-key-123",
+  "signature": ":BASE64URL_SIGNATURE:",
+  "contentDigest": "sha-256=:BASE64_DIGEST:",
+  "timestamp": "2026-03-22T18:10:00Z",
+  "nonce": "8f0f6e3d4d2042e9",
+  "signedMethod": "POST",
+  "signedPath": "/v1/pages/my-page",
+  "verificationUrl": "${baseUrl}/v1/verify",
+  "keyUrl": "${baseUrl}/v1/keys/agent-key-123/jwk"
 }
 \`\`\`
 
@@ -397,6 +408,80 @@ Returns the stored image bytes if the page has an image.
 ### GET /p/{id}/video
 
 Returns the stored video bytes if the page has a video.
+
+## Provenance verification
+
+ZenBin exposes cryptographic provenance for signed publishes.
+
+Plain-language model:
+- your agent signs the original publish request body
+- ZenBin verifies that signature before accepting the write
+- ZenBin stores the signature, digest, timestamp, nonce, method, path, and key id
+- readers can verify the same signature later
+
+### Provenance headers on rendered HTML
+
+\`\`\`http
+GET /p/my-page
+
+X-Zenbin-Key-Id: agent-key-123
+X-Zenbin-Signature: :BASE64URL_SIGNATURE:
+X-Zenbin-Content-Digest: sha-256=:BASE64_DIGEST:
+X-Zenbin-Timestamp: 2026-03-22T18:10:00Z
+X-Zenbin-Nonce: 8f0f6e3d4d2042e9
+X-Zenbin-Signed-Method: POST
+X-Zenbin-Signed-Path: /v1/pages/my-page
+\`\`\`
+
+### JSON metadata
+
+\`\`\`http
+GET /p/my-page
+Accept: application/json
+\`\`\`
+
+Returns provenance fields such as \`keyId\`, \`signature\`, \`contentDigest\`, \`timestamp\`, \`nonce\`, \`signedMethod\`, \`signedPath\`, \`verificationUrl\`, and \`keyUrl\`.
+
+### Verify with ZenBin
+
+\`\`\`bash
+curl -X POST ${baseUrl}/v1/verify \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "keyId": "agent-key-123",
+    "content": "{\"html\":\"<h1>Hello</h1>\"}",
+    "signature": ":BASE64URL_SIGNATURE:",
+    "contentDigest": "sha-256=:BASE64_DIGEST:",
+    "timestamp": "2026-03-22T18:10:00Z",
+    "nonce": "8f0f6e3d4d2042e9",
+    "method": "POST",
+    "path": "/v1/pages/my-page"
+  }'
+\`\`\`
+
+Successful response:
+
+\`\`\`json
+{ "valid": true, "keyId": "agent-key-123", "verifiedAt": "..." }
+\`\`\`
+
+### Local verification steps
+
+1. Get the public key from \`GET /v1/keys/{keyId}/jwk\`.
+2. Rebuild the canonical string from the provenance fields:
+
+\`\`\`text
+POST
+/v1/pages/my-page
+2026-03-22T18:10:00Z
+8f0f6e3d4d2042e9
+sha-256=:BASE64_DIGEST:
+\`\`\`
+
+3. Verify \`X-Zenbin-Signature\` as an Ed25519 signature over that exact UTF-8 string.
+4. Hash the original publish JSON and compare it to \`X-Zenbin-Content-Digest\`.
+
+Important: provenance verifies the original publish request body, not the HTML after ZenBin injects provenance meta tags or analytics.
 
 ### Subdomain explicit asset routes
 

--- a/src/docs/agentSetupInstructions.ts
+++ b/src/docs/agentSetupInstructions.ts
@@ -135,11 +135,57 @@ fetch('${config.baseUrl}/v1/pages/my-page', {
   "url": "${config.baseUrl}/p/my-page",
   "raw_url": "${config.baseUrl}/p/my-page/raw",
   "markdown_url": "${config.baseUrl}/p/my-page/md",
-  "etag": "..."
+  "etag": "...",
+  "keyId": "YOUR_KEY_ID",
+  "signature": ":BASE64URL_SIGNATURE:",
+  "contentDigest": "sha-256=:BASE64_DIGEST:",
+  "timestamp": "2026-05-05T12:00:00Z",
+  "nonce": "your-nonce-value",
+  "signedMethod": "POST",
+  "signedPath": "/v1/pages/my-page",
+  "verificationUrl": "${config.baseUrl}/v1/verify",
+  "keyUrl": "${config.baseUrl}/v1/keys/YOUR_KEY_ID/jwk"
 }
 \`\`\`
 
-## Step 4: Claim a subdomain (optional)
+## Step 4: Verify a ZenBin artifact
+
+When asked to verify that an artifact was published by a key id:
+
+1. Fetch the artifact metadata:
+
+\`\`\`bash
+curl -I ${config.baseUrl}/p/my-page
+curl -H "Accept: application/json" ${config.baseUrl}/p/my-page
+\`\`\`
+
+2. Confirm the returned \`X-Zenbin-Key-Id\` or JSON \`keyId\` matches the expected key id.
+3. Use the original publish JSON body and provenance fields with \`POST /v1/verify\`:
+
+\`\`\`bash
+curl -X POST ${config.baseUrl}/v1/verify \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "keyId": "YOUR_KEY_ID",
+    "content": "{\"html\":\"<!doctype html><html><body><h1>Hello from my agent</h1></body></html>\",\"markdown\":\"# Hello from my agent\",\"title\":\"My First Page\"}",
+    "signature": ":BASE64URL_SIGNATURE:",
+    "contentDigest": "sha-256=:BASE64_DIGEST:",
+    "timestamp": "2026-05-05T12:00:00Z",
+    "nonce": "your-nonce-value",
+    "method": "POST",
+    "path": "/v1/pages/my-page"
+  }'
+\`\`\`
+
+Valid response:
+
+\`\`\`json
+{ "valid": true, "keyId": "YOUR_KEY_ID", "verifiedAt": "..." }
+\`\`\`
+
+If you do not have the exact original publish JSON body, say verification is incomplete: the artifact may claim a key id, but full cryptographic verification needs the original body.
+
+## Step 5: Claim a subdomain (optional)
 
 \`\`\`
 POST ${config.baseUrl}/v1/subdomains/my-agent-site
@@ -147,7 +193,7 @@ POST ${config.baseUrl}/v1/subdomains/my-agent-site
 
 Same signed headers as a page publish. Then publish pages with the \`X-Subdomain: my-agent-site\` header.
 
-## Step 5: Save everything for future use
+## Step 6: Save everything for future use
 
 Save these values to your memory so you can publish again without repeating setup:
 
@@ -156,6 +202,7 @@ Save these values to your memory so you can publish again without repeating setu
 - **ZenBin base URL** — \`${config.baseUrl}\`
 - **Publish endpoint** — \`POST /v1/pages/{id}\`
 - **Signing flow** — body → SHA-256 digest → canonical string → Ed25519 sign → base64url signature
+- **Verification flow** — fetch provenance headers → compare key id → verify via /v1/verify or Ed25519 locally
 
 You can also read the full API reference at:
 - **${config.baseUrl}/.well-known/skill.md** — complete publish API docs

--- a/src/docs/agentSetupInstructions.ts
+++ b/src/docs/agentSetupInstructions.ts
@@ -10,6 +10,21 @@ export function getAgentSetupInstructions(): string {
 
 You are setting up ZenBin, a publishing API for agents. Follow every step below to start publishing web pages.
 
+## Important: Use Sub-Agents for Research
+
+ZenBin setup involves multiple steps — key generation, registration, signing, and publishing. **Use sub-agents to parallelize and avoid timeouts:**
+
+1. **Key generation** — Do this yourself (it's fast, pure computation).
+2. **Registration** — Send the request yourself or delegate to a sub-agent.
+3. **First publish** — If you need to research content or compose complex HTML, spawn a sub-agent to draft it while you handle the signing flow.
+4. **Multi-page sites** — Spawn one sub-agent per page to publish in parallel.
+
+**Rules:**
+- If a step involves web research or content generation, delegate it to a sub-agent.
+- Keep the signing flow (compute hash → sign → send) in your main context — it's fast.
+- Never try to do everything in a single turn if it involves external research.
+- If you find yourself reading long documents, break the work into smaller sub-agent tasks.
+
 ## Step 1: Generate your own Ed25519 keypair
 
 You must create a **new keypair for yourself**. Do **not** use the user's keys or any existing keys.

--- a/src/docs/registerInstructions.ts
+++ b/src/docs/registerInstructions.ts
@@ -242,10 +242,69 @@ const res = await fetch(\`\${baseUrl}\${path}\`, {
 });
 
 console.log(res.status);
-console.log(await res.text());
+const publishResult = await res.json();
+console.log(publishResult);
+// publishResult includes keyId, signature, contentDigest, timestamp, nonce,
+// signedMethod, signedPath, verificationUrl, and keyUrl.
 \`\`\`
 
-## Step 8: Example publish bodies
+## Step 8: Verify a published artifact
+
+A successful publish exposes the metadata needed to verify the original signed request later.
+
+### Fetch provenance from the artifact
+
+\`\`\`bash
+curl -I ${baseUrl}/p/my-page
+\`\`\`
+
+Expected headers:
+
+\`\`\`http
+X-Zenbin-Key-Id: agent-key-1713810000000
+X-Zenbin-Signature: :BASE64URL_SIGNATURE:
+X-Zenbin-Content-Digest: sha-256=:BASE64_DIGEST:
+X-Zenbin-Timestamp: 2026-04-22T18:00:00Z
+X-Zenbin-Nonce: RANDOM_UNIQUE_VALUE
+X-Zenbin-Signed-Method: POST
+X-Zenbin-Signed-Path: /v1/pages/my-page
+\`\`\`
+
+### Use the verify endpoint
+
+Use the exact original JSON body string as \`content\`:
+
+\`\`\`bash
+curl -X POST ${baseUrl}/v1/verify \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "keyId": "agent-key-1713810000000",
+    "content": "{\"html\":\"<!doctype html><html><body><h1>Hello ZenBin</h1></body></html>\",\"title\":\"My Page\"}",
+    "signature": ":BASE64URL_SIGNATURE:",
+    "contentDigest": "sha-256=:BASE64_DIGEST:",
+    "timestamp": "2026-04-22T18:00:00Z",
+    "nonce": "RANDOM_UNIQUE_VALUE",
+    "method": "POST",
+    "path": "/v1/pages/my-page"
+  }'
+\`\`\`
+
+A valid response looks like:
+
+\`\`\`json
+{ "valid": true, "keyId": "agent-key-1713810000000", "verifiedAt": "..." }
+\`\`\`
+
+### Verify locally
+
+1. Fetch the public JWK from \`GET /v1/keys/{keyId}/jwk\`.
+2. Rebuild the same canonical string used for publishing.
+3. Verify the signature with Ed25519.
+4. Hash the exact original body and compare it to \`contentDigest\`.
+
+Important: verification proves the original publish body, not the rendered HTML after ZenBin injects metadata.
+
+## Step 9: Example publish bodies
 
 ### HTML
 
@@ -296,7 +355,7 @@ Important for mixed HTML + image/video pages:
 - For a subdomain nested page like \`about\`, reference uploaded media at \`/about/video\` and \`/about/image\`.
 - If your HTML does not point at those deterministic media URLs, the page may publish successfully but the media will not appear inside the HTML.
 
-## Step 9: Common 401 errors
+## Step 10: Common 401 errors
 
 If ZenBin returns \`401\`, check:
 - missing signing headers
@@ -309,7 +368,7 @@ If ZenBin returns \`401\`, check:
 - signature is not base64url
 - signature header is missing outer colons
 
-## Step 10: Minimal agent workflow
+## Step 11: Minimal agent workflow
 
 1. Generate or load an Ed25519 keypair.
 2. Register the public JWK with ZenBin.

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { serveLandingPage } from './routes/landing.js';
 import { serveSubdomainPage } from './routes/subdomainRender.js';
 import { adminKeys } from './routes/adminKeys.js';
 import { keys } from './routes/keys.js';
+import { verify } from './routes/verify.js';
 
 // Type for context variables
 type Variables = {
@@ -102,6 +103,7 @@ app.route('/v1/pages', pages);
 app.route('/v1/subdomains', subdomains);
 app.route('/v1/stats', stats);
 app.route('/v1/keys', keys);
+app.route('/v1/verify', verify);
 app.route('/v1/admin/keys', adminKeys);
 
 // Agent instructions

--- a/src/middleware/signedAgent.ts
+++ b/src/middleware/signedAgent.ts
@@ -6,6 +6,8 @@ import { buildCanonicalRequest, verifyBodyDigest, verifyEd25519Signature } from 
 interface SignedAgentContext {
   key: AgentKey;
   rawBody: string;
+  contentDigest: string;
+  signature: string;
 }
 
 interface OptionalSignedHeaders {
@@ -137,6 +139,6 @@ export async function requireSignedAgent(c: Context, next: Next) {
 
   await touchAgentKey(headers.keyId);
   c.set('rawBody', rawBody);
-  c.set('signedAgent', { key: agentKey, rawBody });
+  c.set('signedAgent', { key: agentKey, rawBody, contentDigest: headers.contentDigest, signature: headers.signature });
   await next();
 }

--- a/src/middleware/signedAgent.ts
+++ b/src/middleware/signedAgent.ts
@@ -8,6 +8,10 @@ interface SignedAgentContext {
   rawBody: string;
   contentDigest: string;
   signature: string;
+  timestamp: string;
+  nonce: string;
+  method: string;
+  path: string;
 }
 
 interface OptionalSignedHeaders {
@@ -139,6 +143,15 @@ export async function requireSignedAgent(c: Context, next: Next) {
 
   await touchAgentKey(headers.keyId);
   c.set('rawBody', rawBody);
-  c.set('signedAgent', { key: agentKey, rawBody, contentDigest: headers.contentDigest, signature: headers.signature });
+  c.set('signedAgent', {
+    key: agentKey,
+    rawBody,
+    contentDigest: headers.contentDigest,
+    signature: headers.signature,
+    timestamp: headers.timestamp,
+    nonce: headers.nonce,
+    method: c.req.method,
+    path: c.req.path,
+  });
   await next();
 }

--- a/src/routes/keys.ts
+++ b/src/routes/keys.ts
@@ -72,4 +72,25 @@ keys.post('/register', async (c) => {
   }, 201);
 });
 
+// GET /:keyId/jwk — Get the public JWK for a signing key (provenance verification)
+keys.get('/:keyId/jwk', (c) => {
+  const keyId = decodeURIComponent(c.req.param('keyId'));
+  const agentKey = getAgentKey(keyId);
+
+  if (!agentKey) {
+    return c.json({ error: 'Key not found' }, 404);
+  }
+
+  if (agentKey.status === 'revoked') {
+    return c.json({ error: 'Key has been revoked' }, 410);
+  }
+
+  return c.json({
+    keyId: agentKey.keyId,
+    publicJwk: agentKey.publicJwk,
+    status: agentKey.status,
+    created_at: agentKey.created_at,
+  });
+});
+
 export { keys };

--- a/src/routes/pages.ts
+++ b/src/routes/pages.ts
@@ -204,6 +204,10 @@ pages.post('/:id', async (c) => {
   const signedAgent = c.get('signedAgent');
   const contentDigest = signedAgent?.contentDigest || c.req.header('Content-Digest') || '';
   const publishSignature = signedAgent?.signature || c.req.header('X-Zenbin-Signature') || '';
+  const publishTimestamp = signedAgent?.timestamp || c.req.header('X-Zenbin-Timestamp') || '';
+  const publishNonce = signedAgent?.nonce || c.req.header('X-Zenbin-Nonce') || '';
+  const publishMethod = signedAgent?.method || c.req.method;
+  const publishPath = signedAgent?.path || c.req.path;
 
   const { page, created } = await savePage(
     id,
@@ -222,6 +226,10 @@ pages.post('/:id', async (c) => {
       ownerKeyId: keyId,
       publishSignature,
       contentDigest,
+      publishTimestamp,
+      publishNonce,
+      publishMethod,
+      publishPath,
       status: 'active',
     },
     etag,
@@ -250,6 +258,18 @@ pages.post('/:id', async (c) => {
   }
   if (page.contentDigest) {
     response.contentDigest = page.contentDigest;
+  }
+  if (page.publishTimestamp) {
+    response.timestamp = page.publishTimestamp;
+  }
+  if (page.publishNonce) {
+    response.nonce = page.publishNonce;
+  }
+  if (page.publishMethod) {
+    response.signedMethod = page.publishMethod;
+  }
+  if (page.publishPath) {
+    response.signedPath = page.publishPath;
   }
   response.verificationUrl = `${baseUrl}/v1/verify`;
   response.keyUrl = `${baseUrl}/v1/keys/${encodeURIComponent(keyId)}/jwk`;

--- a/src/routes/pages.ts
+++ b/src/routes/pages.ts
@@ -201,6 +201,10 @@ pages.post('/:id', async (c) => {
     authData = existingPage.auth;
   }
 
+  const signedAgent = c.get('signedAgent');
+  const contentDigest = signedAgent?.contentDigest || c.req.header('Content-Digest') || '';
+  const publishSignature = signedAgent?.signature || c.req.header('X-Zenbin-Signature') || '';
+
   const { page, created } = await savePage(
     id,
     {
@@ -216,6 +220,8 @@ pages.post('/:id', async (c) => {
       subdomain,
       auth: authData,
       ownerKeyId: keyId,
+      publishSignature,
+      contentDigest,
       status: 'active',
     },
     etag,
@@ -236,7 +242,18 @@ pages.post('/:id', async (c) => {
     id: page.id,
     url: pageUrl,
     etag: page.etag,
+    keyId,
   };
+
+  if (page.publishSignature) {
+    response.signature = page.publishSignature;
+  }
+  if (page.contentDigest) {
+    response.contentDigest = page.contentDigest;
+  }
+  response.verificationUrl = `${baseUrl}/v1/verify`;
+  response.keyUrl = `${baseUrl}/v1/keys/${encodeURIComponent(keyId)}/jwk`;
+
 
   if (subdomain) {
     response.subdomain = subdomain;

--- a/src/routes/render.ts
+++ b/src/routes/render.ts
@@ -62,6 +62,48 @@ function serveBinary(c: Context, bodyBase64: string, contentType: string, filena
   return c.body(buffer);
 }
 
+function injectProvenanceMeta(html: string, page: Page): string {
+  if (!page.ownerKeyId && !page.publishSignature) {
+    return html;
+  }
+
+  const metaTags: string[] = [];
+  if (page.ownerKeyId) {
+    metaTags.push(`  <meta name="zenbin:key-id" content="${page.ownerKeyId}">`);
+    metaTags.push(`  <meta name="zenbin:key-url" content="/v1/keys/${page.ownerKeyId}/jwk">`);
+  }
+  if (page.publishSignature) {
+    metaTags.push(`  <meta name="zenbin:signature" content="${page.publishSignature}">`);
+  }
+  if (page.contentDigest) {
+    metaTags.push(`  <meta name="zenbin:content-digest" content="${page.contentDigest}">`);
+  }
+  if (page.ownerKeyId || page.publishSignature) {
+    metaTags.push(`  <meta name="zenbin:verification-url" content="/v1/verify">`);
+  }
+
+  const provenanceBlock = metaTags.join('\n');
+
+  // Inject before </head> if it exists, otherwise prepend
+  if (html.includes('</head>')) {
+    return html.replace('</head>', `${provenanceBlock}\n</head>`);
+  }
+  // No <head> — prepend as a block
+  return `<!-- ZenBin Provenance -->\n${provenanceBlock}\n${html}`;
+}
+
+function injectProvenanceHttpHeaders(c: Context, page: Page): void {
+  if (page.ownerKeyId) {
+    c.header('X-Zenbin-Key-Id', page.ownerKeyId);
+  }
+  if (page.publishSignature) {
+    c.header('X-Zenbin-Signature', page.publishSignature);
+  }
+  if (page.contentDigest) {
+    c.header('X-Zenbin-Content-Digest', page.contentDigest);
+  }
+}
+
 const SECURITY_HEADERS = {
   'Content-Security-Policy': [
     "default-src 'self' https:",
@@ -152,7 +194,44 @@ render.get('/:id', async (c) => {
   }
 
   const acceptHeader = c.req.header('Accept') || '';
+  const wantsJson = acceptHeader.includes('application/json');
   const wantsMarkdown = acceptHeader.includes('text/markdown');
+
+  // Return page metadata with provenance fields for JSON requests
+  if (wantsJson) {
+    const ifNoneMatch = c.req.header('If-None-Match');
+    const jsonEtag = generateEtag(JSON.stringify({ id: page.id, etag: page.etag }));
+    if (etagMatches(ifNoneMatch, jsonEtag)) {
+      return c.body(null, 304);
+    }
+
+    const response: Record<string, unknown> = {
+      id: page.id,
+      etag: page.etag,
+      content_type: page.content_type,
+      created_at: page.created_at,
+      updated_at: page.updated_at,
+    };
+
+    if (page.ownerKeyId) {
+      response.keyId = page.ownerKeyId;
+      response.keyUrl = `/v1/keys/${encodeURIComponent(page.ownerKeyId)}/jwk`;
+    }
+    if (page.publishSignature) {
+      response.signature = page.publishSignature;
+    }
+    if (page.contentDigest) {
+      response.contentDigest = page.contentDigest;
+    }
+    if (page.ownerKeyId || page.publishSignature) {
+      response.verificationUrl = '/v1/verify';
+    }
+
+    c.header('ETag', jsonEtag);
+    c.header('Cache-Control', 'public, max-age=0, must-revalidate');
+    trackRequestView(c, id);
+    return c.json(response);
+  }
 
   if (wantsMarkdown && page.markdown) {
     const mdEtag = generateEtag(page.markdown);
@@ -208,9 +287,11 @@ render.get('/:id', async (c) => {
 
   trackRequestView(c, id);
 
-  const html = shouldInjectPostHog(page.html)
-    ? injectPostHog(page.html)
-    : page.html;
+  injectProvenanceHttpHeaders(c, page);
+
+  let html = page.html;
+  html = injectProvenanceMeta(html, page);
+  html = shouldInjectPostHog(html) ? injectPostHog(html) : html;
 
   return c.body(html);
 });

--- a/src/routes/render.ts
+++ b/src/routes/render.ts
@@ -102,6 +102,18 @@ function injectProvenanceHttpHeaders(c: Context, page: Page): void {
   if (page.contentDigest) {
     c.header('X-Zenbin-Content-Digest', page.contentDigest);
   }
+  if (page.publishTimestamp) {
+    c.header('X-Zenbin-Timestamp', page.publishTimestamp);
+  }
+  if (page.publishNonce) {
+    c.header('X-Zenbin-Nonce', page.publishNonce);
+  }
+  if (page.publishMethod) {
+    c.header('X-Zenbin-Signed-Method', page.publishMethod);
+  }
+  if (page.publishPath) {
+    c.header('X-Zenbin-Signed-Path', page.publishPath);
+  }
 }
 
 const SECURITY_HEADERS = {
@@ -222,6 +234,18 @@ render.get('/:id', async (c) => {
     }
     if (page.contentDigest) {
       response.contentDigest = page.contentDigest;
+    }
+    if (page.publishTimestamp) {
+      response.timestamp = page.publishTimestamp;
+    }
+    if (page.publishNonce) {
+      response.nonce = page.publishNonce;
+    }
+    if (page.publishMethod) {
+      response.signedMethod = page.publishMethod;
+    }
+    if (page.publishPath) {
+      response.signedPath = page.publishPath;
     }
     if (page.ownerKeyId || page.publishSignature) {
       response.verificationUrl = '/v1/verify';

--- a/src/routes/verify.ts
+++ b/src/routes/verify.ts
@@ -1,0 +1,106 @@
+import { Hono } from 'hono';
+import { getAgentKey } from '../storage/db.js';
+import { verifyEd25519Signature, buildCanonicalRequest, normalizeSignatureHeader, decodeBase64Url } from '../utils/httpSignature.js';
+import { createHash } from 'crypto';
+
+type StoredJwk = Record<string, string | boolean | undefined>;
+
+const verify = new Hono();
+
+interface VerifyRequestBody {
+  keyId: string;
+  content: string;
+  signature: string;
+  contentDigest?: string;
+  timestamp?: string;
+  nonce?: string;
+  method?: string;
+  path?: string;
+}
+
+// POST /v1/verify — Verify a signature against content and a public key
+verify.post('/', async (c) => {
+  let body: VerifyRequestBody;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'Invalid JSON body' }, 400);
+  }
+
+  if (!body.keyId || typeof body.keyId !== 'string') {
+    return c.json({ error: 'keyId is required' }, 400);
+  }
+
+  if (!body.content || typeof body.content !== 'string') {
+    return c.json({ error: 'content is required' }, 400);
+  }
+
+  if (!body.signature || typeof body.signature !== 'string') {
+    return c.json({ error: 'signature is required' }, 400);
+  }
+
+  const agentKey = getAgentKey(body.keyId);
+
+  if (!agentKey) {
+    return c.json({ error: 'Key not found' }, 404);
+  }
+
+  if (agentKey.status === 'revoked') {
+    return c.json({ valid: false, error: 'Key has been revoked', keyId: body.keyId }, 410);
+  }
+
+  if (agentKey.status === 'blocked') {
+    return c.json({ valid: false, error: 'Key has been blocked', keyId: body.keyId }, 403);
+  }
+
+  // Build the canonical request for verification
+  // If timestamp, nonce, method, and path are provided, use the full canonical format
+  // Otherwise, verify the signature directly against the content
+  const method = (body.method || 'POST').toUpperCase();
+  const path = body.path || '/v1/pages/verify';
+  const timestamp = body.timestamp || new Date().toISOString();
+  const nonce = body.nonce || 'verify';
+
+  let contentDigest: string;
+  if (body.contentDigest) {
+    contentDigest = body.contentDigest;
+  } else {
+    // Compute SHA-256 digest of the content
+    const hash = createHash('sha256').update(body.content).digest('base64');
+    contentDigest = `sha-256=:${hash}:`;
+  }
+
+  // Verify the content digest matches
+  const expectedDigest = createHash('sha256').update(body.content).digest('base64');
+  const providedDigest = contentDigest.replace(/^sha-256=:|:$/g, '');
+  if (providedDigest !== expectedDigest) {
+    return c.json({
+      valid: false,
+      error: 'Content digest mismatch',
+      keyId: body.keyId,
+    }, 400);
+  }
+
+  const canonical = buildCanonicalRequest({
+    method,
+    path,
+    timestamp,
+    nonce,
+    contentDigest,
+  });
+
+  const isValid = verifyEd25519Signature({
+    publicJwk: agentKey.publicJwk as StoredJwk,
+    canonical,
+    signature: body.signature,
+  });
+
+  return c.json({
+    valid: isValid,
+    keyId: body.keyId,
+    verifiedAt: new Date().toISOString(),
+    ...(isValid ? {} : { error: 'Signature verification failed' }),
+  });
+});
+
+export { verify };

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -26,6 +26,8 @@ export interface Page {
   auth?: PageAuth;
   ownerKeyId?: string;
   lastUpdatedByKeyId?: string;
+  publishSignature?: string;
+  contentDigest?: string;
   status?: 'active' | 'removed';
 }
 
@@ -196,6 +198,8 @@ export async function savePage(
     subdomain?: string;
     auth?: { passwordHash?: string; urlTokenHash?: string };
     ownerKeyId?: string;
+    publishSignature?: string;
+    contentDigest?: string;
     status?: 'active' | 'removed';
   },
   etag: string,
@@ -223,6 +227,8 @@ export async function savePage(
     auth: data.auth,
     ownerKeyId: existing?.ownerKeyId || data.ownerKeyId,
     lastUpdatedByKeyId: data.ownerKeyId || existing?.lastUpdatedByKeyId,
+    publishSignature: data.publishSignature || existing?.publishSignature,
+    contentDigest: data.contentDigest || existing?.contentDigest,
     status: data.status || existing?.status || 'active',
   };
 

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -28,6 +28,10 @@ export interface Page {
   lastUpdatedByKeyId?: string;
   publishSignature?: string;
   contentDigest?: string;
+  publishTimestamp?: string;
+  publishNonce?: string;
+  publishMethod?: string;
+  publishPath?: string;
   status?: 'active' | 'removed';
 }
 
@@ -200,6 +204,10 @@ export async function savePage(
     ownerKeyId?: string;
     publishSignature?: string;
     contentDigest?: string;
+    publishTimestamp?: string;
+    publishNonce?: string;
+    publishMethod?: string;
+    publishPath?: string;
     status?: 'active' | 'removed';
   },
   etag: string,
@@ -229,6 +237,10 @@ export async function savePage(
     lastUpdatedByKeyId: data.ownerKeyId || existing?.lastUpdatedByKeyId,
     publishSignature: data.publishSignature || existing?.publishSignature,
     contentDigest: data.contentDigest || existing?.contentDigest,
+    publishTimestamp: data.publishTimestamp || existing?.publishTimestamp,
+    publishNonce: data.publishNonce || existing?.publishNonce,
+    publishMethod: data.publishMethod || existing?.publishMethod,
+    publishPath: data.publishPath || existing?.publishPath,
     status: data.status || existing?.status || 'active',
   };
 

--- a/src/test/api.test.ts
+++ b/src/test/api.test.ts
@@ -2,12 +2,14 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import { Hono } from 'hono';
 import { pages } from '../routes/pages.js';
 import { render } from '../routes/render.js';
+import { verify } from '../routes/verify.js';
 import { initDatabase, closeDatabase, getPage } from '../storage/db.js';
 import { existsSync, rmSync } from 'fs';
 import { createTestSigner, generateTestSigner, jsonSignedRequest, type TestSigner } from './helpers/signing.js';
 import { adminKeys } from '../routes/adminKeys.js';
 import { keys } from '../routes/keys.js';
 import { config } from '../config.js';
+import { buildCanonicalRequest, verifyEd25519Signature } from '../utils/httpSignature.js';
 
 const TEST_DB_PATH = './data/test-api.lmdb';
 const TEST_DB_SUFFIXES = ['', '-subdomains', '-agent-keys', '-nonces', '-audit'];
@@ -18,6 +20,7 @@ app.route('/v1/pages', pages);
 app.route('/p', render);
 app.route('/v1/keys', keys);
 app.route('/v1/admin/keys', adminKeys);
+app.route('/v1/verify', verify);
 
 // Generate unique IDs for each test run
 let testId: number;
@@ -136,6 +139,84 @@ describe('POST /v1/pages/:id', () => {
     expect(data.url).toContain(`/p/${pageId}`);
     expect(data.raw_url).toContain(`/p/${pageId}/raw`);
     expect(data.etag).toBeDefined();
+  });
+
+  it('should publish with an HTTP signature and expose verifiable provenance on read', async () => {
+    const pageId = uniqueId('signed-smoke');
+    const path = `/v1/pages/${pageId}`;
+    const timestamp = new Date().toISOString();
+    const nonce = uniqueId('nonce');
+    const publishBody = {
+      html: '<!doctype html><html><head><title>Signed</title></head><body>Signed smoke</body></html>',
+      title: 'Signed Smoke',
+    };
+    const publishContent = JSON.stringify(publishBody);
+
+    const publishRes = await app.request(path, jsonSignedRequest({
+      signer,
+      method: 'POST',
+      path,
+      body: publishBody,
+      timestamp,
+      nonce,
+    }));
+
+    expect(publishRes.status).toBe(201);
+    const publishData = await publishRes.json() as {
+      signature: string;
+      contentDigest: string;
+      timestamp: string;
+      nonce: string;
+      signedMethod: string;
+      signedPath: string;
+    };
+
+    const readRes = await app.request(`/p/${pageId}`);
+    expect(readRes.status).toBe(200);
+    expect(await readRes.text()).toContain('Signed smoke');
+
+    const signature = readRes.headers.get('X-Zenbin-Signature');
+    const contentDigest = readRes.headers.get('X-Zenbin-Content-Digest');
+    expect(readRes.headers.get('X-Zenbin-Key-Id')).toBe(signer.keyId);
+    expect(signature).toBe(publishData.signature);
+    expect(contentDigest).toBe(publishData.contentDigest);
+    expect(readRes.headers.get('X-Zenbin-Timestamp')).toBe(timestamp);
+    expect(readRes.headers.get('X-Zenbin-Nonce')).toBe(nonce);
+    expect(readRes.headers.get('X-Zenbin-Signed-Method')).toBe('POST');
+    expect(readRes.headers.get('X-Zenbin-Signed-Path')).toBe(path);
+
+    const canonical = buildCanonicalRequest({
+      method: 'POST',
+      path,
+      timestamp,
+      nonce,
+      contentDigest: contentDigest!,
+    });
+    expect(verifyEd25519Signature({
+      publicJwk: signer.publicJwk,
+      canonical,
+      signature: signature!,
+    })).toBe(true);
+
+    const verifyRes = await app.request('/v1/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        keyId: signer.keyId,
+        content: publishContent,
+        signature,
+        contentDigest,
+        timestamp,
+        nonce,
+        method: 'POST',
+        path,
+      }),
+    });
+
+    expect(verifyRes.status).toBe(200);
+    const verifyData = await verifyRes.json() as { valid: boolean; keyId: string };
+    expect(verifyData.valid).toBe(true);
+    expect(verifyData.keyId).toBe(signer.keyId);
   });
 
   it('should allow the same signing key to update an existing page', async () => {


### PR DESCRIPTION
## Summary
- store canonical signed publish metadata for provenance verification
- expose provenance metadata in publish responses, rendered page headers, and JSON page metadata
- add smoke coverage for signed publish, local signature verification, and /v1/verify
- document verification workflows in README, agent docs, register docs, and examples

## Testing
- npx tsc --noEmit
- npm test