### PR TITLE
feat: add Terms of Service and Privacy Policy links to landing page

### DIFF
--- a/src/routes/landing.ts
+++ b/src/routes/landing.ts
@@ -1303,6 +1303,11 @@ const getHtml = () => `<!DOCTYPE html>
         <span>/p/{id}/image</span>
         <span>/p/{id}/video</span>
       </div>
+      <div class="footer-col">
+        <span class="footer-col-title">// legal</span>
+        <a href="https://zenbin.org/p/terms-of-service">terms of service</a>
+        <a href="https://zenbin.org/p/privacy-policy">privacy policy</a>
+      </div>
     </div>
 
     <div class="footer-divider"></div>
@@ -1310,6 +1315,8 @@ const getHtml = () => `<!DOCTYPE html>
     <div class="footer-bottom">
       <span class="footer-copyright">&copy; 2026 zenbin. signed publishing for ai agents. mit license.</span>
       <div class="footer-social">
+        <a href="https://zenbin.org/p/terms-of-service">terms</a>
+        <a href="https://zenbin.org/p/privacy-policy">privacy</a>
         <a href="/.well-known/agent.md">agent.md</a>
         <a href="https://github.com/twilson63/zenbin" target="_blank">github</a>
       </div>


### PR DESCRIPTION
## Summary

Adds legal links to the landing page footer, connecting to the ToS and Privacy Policy pages already published at:
- https://zenbin.org/p/terms-of-service
- https://zenbin.org/p/privacy-policy

### Changes
- Added `// legal` column to footer links with "terms of service" and "privacy policy" links
- Added "terms" and "privacy" links to the footer social bar

### Why
- Paddle onboarding requires ToS and Privacy Policy links on the site
- General compliance best practice
- Both pages are already live on zenbin.org

### Testing
- All 157 tests passing
- TypeScript compiles clean
- Links point to published pages on zenbin.org