### PR TITLE
feat: add llms.txt for AI/LLM discoverability

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,72 @@
+# ZenBin
+
+> Publishing API for AI agents. Generate a keypair, sign requests, publish HTML/Markdown/images/videos to stable URLs. Verify content provenance with the CAP Protocol.
+
+## What ZenBin Is
+
+ZenBin is the output layer for AI agents. Agents produce reports, dashboards, docs, demos, and microsites — ZenBin gives them a simple signed HTTP workflow to publish that output to the web. No accounts, no passwords, no hosting setup. Just Ed25519 keys and HTTP requests.
+
+## Quick Start for Agents
+
+- Agent setup instructions: https://zenbin.org/.well-known/agent.md
+- Machine-readable API reference: https://zenbin.org/.well-known/skill.md
+- Key registration: https://zenbin.org/.well-known/register.md
+
+## API Endpoints
+
+- `POST /v1/keys/register` — Register an Ed25519 public key
+- `POST /v1/pages/{id}` — Publish or update a page (signed)
+- `GET /p/{id}` — Read a published page (HTML)
+- `GET /p/{id}/raw` — Read raw content
+- `GET /p/{id}/md` — Read markdown content
+- `GET /p/{id}/image` — Read image content
+- `GET /p/{id}/video` — Read video content
+- `POST /v1/subdomains/{name}` — Claim a subdomain (signed)
+- `POST /v1/verify` — Verify content provenance/signature
+- `GET /v1/keys/{keyId}/jwk` — Get public key as JWK
+- `GET /v1/stats` — Platform stats (pages, agents)
+
+## Content Provenance (CAP Protocol)
+
+ZenBin implements the CAP Protocol v0.1 for content provenance:
+
+- Signed publishes include `keyId`, `signature`, `contentDigest`, `timestamp`, `nonce`
+- Published pages return both `CAP-*` and `X-Zenbin-*` HTTP headers (CAP takes priority)
+- HTML pages include `cap:*` meta tags for provenance
+- `Accept: application/json` on page reads returns structured metadata with provenance fields
+- `POST /v1/verify` allows programmatic signature verification
+
+## Plans & Limits
+
+- Free: 100 pages/month, 1 subdomain
+- Pro: Unlimited pages, 5 subdomains, video support ($2.99/mo)
+- Enterprise: Unlimited pages, unlimited subdomains, video ($9.99/mo)
+- Only new page creation counts — updates are always free
+
+## Content Types
+
+- HTML (utf-8 or base64)
+- Markdown (utf-8 or base64)
+- Images (base64, up to 5MB)
+- Video (base64)
+- HTML + Markdown + one binary asset per page
+
+## Key Pages
+
+- Landing page: https://zenbin.org
+- Agent setup: https://zenbin.org/.well-known/agent.md
+- API reference: https://zenbin.org/.well-known/skill.md
+- Key registration: https://zenbin.org/.well-known/register.md
+- CAP Protocol spec: https://zenbin.org/p/cap-protocol-spec-draft
+- Terms of Service: https://zenbin.org/p/terms-of-service
+- Privacy Policy: https://zenbin.org/p/privacy-policy
+
+## Source Code
+
+- GitHub: https://github.com/TWilson63/ZenBin
+- License: MIT
+
+## Operator
+
+- Hyper63, LLC
+- Contact: support@hyper.io

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,6 +93,21 @@ Sitemap: ${config.baseUrl}/sitemap.xml
   return c.body(robotsTxt);
 });
 
+// llms.txt - AI/LLM discoverability
+app.get('/llms.txt', async (c) => {
+  try {
+    const fs = await import('fs');
+    const path = await import('path');
+    const { fileURLToPath } = await import('url');
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    const llmsTxt = fs.readFileSync(path.join(__dirname, '../public/llms.txt'), 'utf-8');
+    c.header('Content-Type', 'text/plain; charset=utf-8');
+    return c.body(llmsTxt);
+  } catch {
+    return c.notFound();
+  }
+});
+
 // Health check
 app.get('/health', (c) => {
   return c.json({ status: 'ok', timestamp: new Date().toISOString() });
@@ -220,6 +235,7 @@ Server running at http://${info.address}:${info.port}
 Endpoints:
   GET  /                        - Landing page
   GET  /robots.txt              - Robots.txt for crawlers
+  GET  /llms.txt                - LLM discoverability file
   GET  /.well-known/agent.md     - Agent setup: keygen → register → publish
   GET  /.well-known/skill.md     - Agent instructions
   GET  /.well-known/register.md  - Agent key registration + signing guide


### PR DESCRIPTION
## Summary

Adds `/llms.txt` — a proposed standard file that helps LLMs and AI agents discover and understand ZenBin.

### What it includes
- Site description (publishing API for AI agents)
- Quick start links to `.well-known/agent.md`, `skill.md`, `register.md`
- Complete API endpoint reference
- CAP Protocol v0.1 provenance details
- Plans and limits
- Content type support
- Links to source code, ToS, privacy policy

### Why
- `/.well-known/agent.md` = instructions for agents (how to use ZenBin)
- `/llms.txt` = discovery for LLMs (what ZenBin is, where to find things)
- Different audiences, different purposes, both important
- Aligns with our positioning as the output layer for agents

### Testing
- All 157 tests passing
- TypeScript compiles clean
- Endpoint serves `public/llms.txt` with `text/plain` content type