### PR TITLE
security: replace literal admin token in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,10 +13,12 @@ LMDB_PATH=./data/zenbin.lmdb
 # Auth
 # Required for JWT-based API key verification (legacy path).
 # Primary auth is Ed25519 signed requests — this is only needed for portal-issued keys.
+# Generate: openssl rand -base64 32
 ZENBIN_JWT_SECRET=
 
-# Admin API access token
-ADMIN_TOKEN=dev-admin-token
+# Admin API access token — CHANGE THIS to a random secret in production.
+# Generate: openssl rand -base64 32
+ADMIN_TOKEN=
 
 # Limits
 MAX_PAYLOAD_SIZE=524288


### PR DESCRIPTION
## Summary

Replaces the exposed `ADMIN_TOKEN=dev-admin-token` placeholder in `env.example` with instructions to generate a random secret.

## What Changed

- `env.example` — replaced the literal `dev-admin-token` value with a placeholder directive to generate a random secret using `openssl rand -base64 32`
- Added generation hints for both `ZENBIN_JWT_SECRET` and `ADMIN_TOKEN`

## Why

Anyone cloning the repo and following the example literally would deploy with a known admin token, allowing unauthorized access to admin API routes (key management, blocking/revoking signing keys).

## Status

- [`fa09f51`](https://github.com/twilson63/zenbin/commit/fa09f51) ← branched from main
- [`b16374d`](https://github.com/twilson63/zenbin/commit/b16374d) — this fix

## Notes

- `.env` was never committed to git history (properly in `.gitignore`). No git history scrubbing needed.
- Consider rotating PostHog + Stripe test keys since they were exposed during a code review session.