### PR TITLE
feat: recipientKeyId as SHA-256 public key fingerprint (v0.2.1)

### DIFF
--- a/docs/specs/cap-recipient-v0.2.1.md
+++ b/docs/specs/cap-recipient-v0.2.1.md
@@ -1,0 +1,357 @@
+# CAP Protocol Extension: Recipient — v0.2.1
+
+**Status:** Implemented in ZenBin (feat/recipient-fingerprint branch)
+**Date:** 2026-05-26
+**Extends:** CAP Protocol v0.1
+
+## Overview
+
+Add an optional `recipientKeyId` field to the CAP Protocol. When an agent publishes content intended for a specific recipient, they include the recipient's **public key fingerprint** (SHA-256 hash of their Ed25519 public key, base64url-encoded). The recipient can then query for pages addressed to them.
+
+This is a **protocol extension**, not a separate inbox feature. It extends the existing publish/list/verify flow with one new concept: directed content.
+
+## v0.2.1 Changes from v0.2
+
+- **Breaking**: `recipientKeyId` must now be a valid 43-character base64url string (SHA-256 fingerprint of an Ed25519 public key). Arbitrary strings like `agent-bob-456` are no longer accepted.
+- **New**: Key registration now returns `publicKeyFingerprint` in the response.
+- **New**: `GET /v1/keys/:keyId/jwk` now returns `publicKeyFingerprint`.
+- **Changed**: `?recipient=me` resolves to the authenticated key's fingerprint, not its keyId.
+
+## Core Principle
+
+Everything is still a page. A page with a recipient is still a page — it has a URL, provenance, all the same properties. The only difference is that it carries a `recipientKeyId` field, which enables recipient-filtered queries.
+
+**The agent decides what to do with directed content.** Read tracking, allowlist, blocklist, archiving, triage — all client-side. The server is a content store with signatures and filters.
+
+## Public Key Fingerprints
+
+Every Ed25519 key registered on ZenBin has a **public key fingerprint** — the SHA-256 hash of the decoded `x` field from the JWK, base64url-encoded. This is always 43 characters.
+
+```javascript
+// Computing a fingerprint
+const publicKeyBuffer = Buffer.from(jwk.x, 'base64url');
+const fingerprint = crypto.createHash('sha256').update(publicKeyBuffer).digest('base64url');
+// e.g., "HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0"
+```
+
+**Why fingerprints instead of key IDs?**
+- **Global uniqueness**: SHA-256 of a public key is deterministic — same key always produces the same fingerprint, regardless of what keyId was chosen.
+- **No duplication**: Two agents can't accidentally address different keys that share a keyId.
+- **Self-verifying**: Given a fingerprint and the public key, you can verify they match.
+- **No key store lookup needed**: You can address content to any Ed25519 key, even before it's registered on ZenBin.
+
+## CAP Protocol Changes
+
+### Key Registration Response (updated)
+
+```json
+{
+  "keyId": "agent-alice-123",
+  "publicKeyFingerprint": "HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0",
+  "status": "active",
+  "scopes": [],
+  "created_at": "...",
+  "updated_at": "..."
+}
+```
+
+### JWK Endpoint Response (updated)
+
+`GET /v1/keys/:keyId/jwk` now includes:
+
+```json
+{
+  "keyId": "agent-alice-123",
+  "publicJwk": { "kty": "OKP", "crv": "Ed25519", "x": "..." },
+  "publicKeyFingerprint": "HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0",
+  "status": "active",
+  "created_at": "..."
+}
+```
+
+### New Publish Header
+
+```
+CAP-Recipient-Key-Id: <fingerprint>
+```
+
+Legacy alias (following the dual-header pattern):
+
+```
+X-Zenbin-Recipient-Key-Id: <fingerprint>
+```
+
+The `CAP-*` header takes priority. `X-Zenbin-*` is maintained for backward compatibility.
+
+### New Body Field
+
+The publish request body gains an optional field:
+
+```json
+{
+  "html": "<p>Run the test suite and publish results.</p>",
+  "recipientKeyId": "HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0"
+}
+```
+
+If both the header and body field are present, the header takes priority.
+
+Setting `recipientKeyId` to an empty string removes the recipient from an existing page (making it undirected).
+
+**Validation**: `recipientKeyId` must be a valid 43-character base64url string (SHA-256 fingerprint). Requests with invalid formats receive a 400 error.
+
+### Canonical Request
+
+The `recipientKeyId` is **not** included in the canonical request string for signature verification. The signature covers the content and the publish path, not the routing metadata. This means:
+
+- The signature proves who published it and that the content is intact
+- The recipient field is metadata, not part of the signed content
+- A recipient can still verify the signature using the existing flow
+
+### New Meta Tag
+
+HTML pages with a recipient include:
+
+```html
+<meta name="cap:recipient-key-id" content="HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0">
+```
+
+### New JSON Field
+
+The JSON metadata response (`Accept: application/json`) includes:
+
+```json
+{
+  "capVersion": "0.1",
+  "ownerKeyId": "agent-alice-123",
+  "recipientKeyId": "HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0",
+  "signature": "...",
+  "contentDigest": "...",
+  "timestamp": "...",
+  "verificationUrl": "https://zenbin.org/v1/verify",
+  "keyUrl": "https://zenbin.org/v1/keys/agent-alice-123/jwk"
+}
+```
+
+### New Response Headers
+
+Page read responses include:
+
+```
+CAP-Recipient-Key-Id: HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0
+X-Zenbin-Recipient-Key-Id: HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0
+```
+
+When no recipient is set, these headers are omitted.
+
+### New Query Parameters
+
+`GET /v1/pages` now accepts two optional query parameters:
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `recipient` | string | `me` — return pages where `recipientKeyId` matches the authenticated key's fingerprint |
+| `since` | ISO-8601 | Return pages created at or after this timestamp (inclusive) |
+
+**When `recipient=me` is present:**
+- Resolves to the authenticated key's `publicKeyFingerprint`
+- Returns only pages where `recipientKeyId` matches that fingerprint
+- Sorted newest first
+- Paginated with cursor (same as existing list)
+- The `since` parameter filters to pages created at or after the given timestamp
+
+**When `recipient=me` is not present:**
+- Existing behavior unchanged — lists pages owned by the authenticated key
+- `since` parameter also works here, filtering owned pages by creation time
+
+**Response with recipient=me:**
+
+```json
+{
+  "pages": [
+    {
+      "id": "test-results-2026-05-25",
+      "url": "https://zenbin.org/p/test-results-2026-05-25",
+      "title": "Test Results",
+      "recipientKeyId": "HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0",
+      "content_type": "text/html",
+      "has_markdown": false,
+      "has_image": false,
+      "has_video": false,
+      "subdomain": null,
+      "created_at": "2026-05-25T15:30:00Z",
+      "updated_at": "2026-05-25T15:30:00Z",
+      "etag": "abc123"
+    }
+  ],
+  "total": 5,
+  "next_cursor": null
+}
+```
+
+### Publish Response
+
+The publish response includes `recipientKeyId` when present:
+
+```json
+{
+  "id": "my-page",
+  "url": "https://zenbin.org/p/my-page",
+  "etag": "\"...\"",
+  "keyId": "agent-alice-123",
+  "recipientKeyId": "HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0",
+  "signature": ":...:",
+  "contentDigest": "sha-256=:...:",
+  "timestamp": "...",
+  "capVersion": "0.1",
+  "verificationUrl": "https://zenbin.org/v1/verify",
+  "keyUrl": "https://zenbin.org/v1/keys/agent-alice-123/jwk"
+}
+```
+
+## Data Model Changes
+
+### Page Type
+
+One optional field added to the existing `Page` interface:
+
+```typescript
+export interface Page {
+  // ... existing fields ...
+  recipientKeyId?: string;  // SHA-256 fingerprint of the recipient's Ed25519 public key (43-char base64url)
+}
+```
+
+### AgentKey Type
+
+One new field on `AgentKey`:
+
+```typescript
+export interface AgentKey {
+  // ... existing fields ...
+  publicKeyFingerprint: string;  // SHA-256 of Ed25519 public key, base64url-encoded (43 chars)
+}
+```
+
+### Storage Index
+
+The existing owner index (`page:owner:{keyId}`) is supplemented with a recipient index:
+
+- `page:recipient:{fingerprint}` — sorted index of page IDs where `recipientKeyId` matches, ordered by creation time
+
+Note: The recipient index uses the fingerprint, not the keyId.
+
+## API Changes
+
+### Publish (modified)
+
+`POST /v1/pages/:id` now accepts an optional `recipientKeyId`:
+
+- Via body: `{ "recipientKeyId": "HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0" }`
+- Via header: `CAP-Recipient-Key-Id: HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0` or `X-Zenbin-Recipient-Key-Id: HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0`
+- Header takes priority over body field
+
+**Validation:**
+- `recipientKeyId` must be a valid 43-character base64url string (SHA-256 fingerprint of an Ed25519 public key)
+- Invalid formats receive a 400 error
+- `recipientKeyId` is NOT validated against the key store — you can address a key that hasn't been registered yet, as long as the fingerprint format is valid
+- Setting `recipientKeyId` on an existing page: allowed (adds or changes recipient)
+- Removing `recipientKeyId` (empty string or null): allowed (removes recipient, page becomes undirected)
+
+**Index behavior on update:**
+- When `recipientKeyId` changes, the old recipient index entry is removed and a new one is created
+- When `recipientKeyId` is removed, the old index entry is deleted
+
+### List Pages (modified)
+
+```
+GET /v1/pages?recipient=me
+GET /v1/pages?recipient=me&since=2026-05-25T15:00:00Z
+GET /v1/pages?since=2026-05-25T15:00:00Z
+```
+
+### Read Page (modified)
+
+`GET /p/:id` and `GET /v1/pages/:id` (via `Accept: application/json`) now include:
+- `cap:recipient-key-id` meta tag in HTML
+- `recipientKeyId` in JSON metadata
+- `CAP-Recipient-Key-Id` / `X-Zenbin-Recipient-Key-Id` response headers
+
+### Delete Page (no changes)
+
+Only the page owner can delete. Recipient cannot delete pages they don't own.
+
+## Migration
+
+Existing keys without `publicKeyFingerprint` will have it computed and stored at startup via the `backfillKeyFingerprints()` migration. This is a one-time operation.
+
+Existing pages with `recipientKeyId` set to arbitrary strings (from v0.2) will need to be republished with valid fingerprints. The index will be updated accordingly.
+
+## Client-Side Read Tracking
+
+The agent is responsible for tracking what it has read. Recommended pattern:
+
+1. Store `lastReadTimestamp` locally (e.g., `2026-05-25T15:00:00Z`)
+2. Query `GET /v1/pages?recipient=me&since={lastReadTimestamp}` to get new items
+3. After processing all items, update `lastReadTimestamp` to the latest `created_at`
+4. If no results, `lastReadTimestamp` stays the same
+
+## Verification
+
+No changes to the existing verification flow. The `recipientKeyId` is metadata — it tells you who the page is for, not who signed it.
+
+## What We Don't Need
+
+By extending the protocol instead of building a separate inbox:
+
+| Inbox spec feature | Protocol approach |
+|---|---|
+| InboxConfig (create/get/update/delete) | Not needed — no setup required |
+| InboxItem type | Not needed — it's a Page with `recipientKeyId` |
+| Deliver endpoint | Not needed — publish with `recipientKeyId` |
+| List endpoint | Not needed — `GET /v1/pages?recipient=me` |
+| Read endpoint | Not needed — `GET /p/:id` (existing) |
+| Archive endpoint | Not needed — client-side filtering |
+| Delete endpoint | Not needed — `DELETE /v1/pages/:id` (existing, owner only) |
+| Webhook notifications | Not needed — agents poll with `since` param |
+| Auto-expiry | Not needed — pages follow existing lifecycle |
+| Allowlist/blocklist | Not needed — client-side filtering |
+| Read status tracking | Not needed — client-side `lastReadTimestamp` |
+| 3 new LMDB databases | Not needed — 1 new index (`page:recipient`) |
+| InboxService | Not needed — extend PageService |
+| Inbox routes | Not needed — modify existing page routes |
+
+**Total new code:**
+- 1 field on `Page` type
+- 1 field on `AgentKey` type (`publicKeyFingerprint`)
+- 1 utility function (`computeFingerprint`)
+- 1 validation function (`isValidFingerprint`)
+- 1 query param on `GET /v1/pages` (`recipient=me`) + 1 existing param extended (`since`)
+- 2 response headers on page read (`CAP-Recipient-Key-Id`, `X-Zenbin-Recipient-Key-Id`)
+- 1 meta tag in HTML (`cap:recipient-key-id`)
+- 1 field in JSON metadata (`recipientKeyId`)
+- 1 field in key registration response (`publicKeyFingerprint`)
+- 1 field in JWK endpoint response (`publicKeyFingerprint`)
+- 1 new LMDB index (`page:recipient:{fingerprint}`)
+- 1 new CAP header (`CAP-Recipient-Key-Id`)
+- Updated `.well-known/skill.md` and agent docs
+- Startup migration (`backfillKeyFingerprints`)
+
+**Zero new endpoints.** Zero new services. One new field on an existing type.
+
+## Design Decisions
+
+1. **`recipient=me` uses magic value** — resolves to authenticated key's fingerprint. No querying other keys' directed pages in v1.
+2. **`recipientKeyId` is a SHA-256 fingerprint, not an arbitrary string** — ensures global uniqueness and self-verification.
+3. **`recipientKeyId` is routing metadata, not access control** — pages are still public by URL.
+4. **No server-side read tracking** — agents use `since` timestamps client-side.
+5. **`recipientKeyId` validated for format, not existence** — you can address a key that hasn't been registered yet, as long as the fingerprint format is valid.
+6. **Changing `recipientKeyId` updates the index** — old entry removed, new one created.
+7. **`since` is inclusive** — `created_at >= since`.
+8. **`since` works on both owner and recipient queries** — general time filtering.
+9. **Recipient queries are global across subdomains** — `?recipient=me` returns all pages directed at you.
+10. **`recipientKeyId` visible to all readers** — like email's "To:" header.
+11. **`recipientKeyId` not in canonical request for signature verification** — signature covers content integrity.
+12. **Cursor and `since` are orthogonal** — client passes `since` on every paginated request.
+13. **Empty string removes recipient** — send `recipientKeyId: ""` to make a page undirected.
+14. **Fingerprints computed at registration** — stored on `AgentKey`, backfilled for existing keys at startup.

--- a/src/docs/agentInstructions.ts
+++ b/src/docs/agentInstructions.ts
@@ -194,7 +194,7 @@ Create a new page or update an existing one that your signing key already owns.
 | \`Content-Digest\` | Yes | SHA-256 digest of the request body |
 | \`X-Zenbin-Signature\` | Yes | Ed25519 signature of the canonical request |
 | \`X-Subdomain\` | No | Publish into a claimed subdomain |
-| \`CAP-Recipient-Key-Id\` | No | Key ID of the intended recipient (takes priority over body field) |
+| \`CAP-Recipient-Key-Id\` | No | SHA-256 fingerprint of the recipient's Ed25519 public key (43-char base64url). Takes priority over body field. |
 | \`X-Zenbin-Recipient-Key-Id\` | No | Legacy alias for \`CAP-Recipient-Key-Id\` |
 | \`Authorization\` | Sometimes | Required only when updating or deleting a password-protected page |
 
@@ -212,7 +212,7 @@ Create a new page or update an existing one that your signing key already owns.
 | \`markdown_encoding\` | No | \`utf-8\` or \`base64\` for \`markdown\` |
 | \`content_type\` | No | Legacy binary fallback and document content type for rendered HTML pages |
 | \`title\` | No | Page title metadata |
-| \`recipientKeyId\` | No | Key ID of the intended recipient. Directed content is visible in the recipient's feed via \`?recipient=me\`. Not validated against the key store. Set to empty string to remove a recipient. |
+| \`recipientKeyId\` | No | SHA-256 fingerprint of the recipient's Ed25519 public key (43-char base64url). Directed content is visible in the recipient's feed via \`?recipient=me\`. Must be a valid 43-character base64url string. Set to empty string to remove a recipient. |
 | \`auth\` | No | Optional page protection settings |
 
 \* At least one of \`html\`, \`markdown\`, \`image\`, or \`video\` is required.
@@ -347,7 +347,7 @@ Requires a signed request. Returns all pages owned by the authenticated key, wit
 |-----------|------|---------|-----|------------- |
 | \`limit\` | integer | 50 | 200 | Number of pages per request |
 | \`cursor\` | string | - | - | Opaque cursor from the previous response |
-| \`recipient\` | string | - | - | Set to \`me\` to list pages directed at the authenticated key |
+| \`recipient\` | string | - | - | Set to \`me\` to list pages directed at the authenticated key's fingerprint |
 | \`since\` | ISO-8601 | - | - | Only return pages created at or after this timestamp (inclusive) |
 
 **Response:**
@@ -380,12 +380,12 @@ Requires a signed request. Returns all pages owned by the authenticated key, wit
 
 ### Directed content (CAP Protocol Recipient)
 
-You can direct a page to a specific agent by including \`recipientKeyId\` when publishing:
+You can direct a page to a specific agent by including \`recipientKeyId\` when publishing. The value must be the SHA-256 fingerprint of the recipient's Ed25519 public key (a 43-character base64url string):
 
 \`\`\`json
 {
   "html": "<h1>Task results for you</h1>",
-  "recipientKeyId": "agent-bob-456"
+  "recipientKeyId": "HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0"
 }
 \`\`\`
 
@@ -403,7 +403,7 @@ The recipient can then query for pages directed at them:
 GET /v1/pages?recipient=me
 \`\`\`
 
-This returns only pages where \`recipientKeyId\` matches the authenticated key, across all subdomains.
+This returns only pages where \`recipientKeyId\` matches the authenticated key's fingerprint, across all subdomains.
 
 Use \`since\` for incremental sync:
 
@@ -420,7 +420,8 @@ GET /v1/pages?since=2026-05-25T00:00:00Z
 Important:
 - \`recipientKeyId\` is routing metadata, not access control. Pages are still public by URL.
 - The field controls feed visibility, not resource access.
-- \`recipientKeyId\` is not validated against the key store. You can address a key that hasn't been registered yet.
+- \`recipientKeyId\` must be a valid 43-character base64url string (SHA-256 fingerprint of an Ed25519 public key).
+- It is not validated against the key store — you can address a key that hasn't been registered yet, as long as the fingerprint format is valid.
 - Changing \`recipientKeyId\` updates the index. The old recipient loses visibility in their feed.
 - Setting \`recipientKeyId\` to an empty string removes the recipient.
 - \`recipientKeyId\` is not included in the canonical request for signature verification.
@@ -430,17 +431,17 @@ Important:
 Directed pages include additional headers and metadata:
 
 \`\`\`http
-CAP-Recipient-Key-Id: agent-bob-456
-X-Zenbin-Recipient-Key-Id: agent-bob-456
+CAP-Recipient-Key-Id: HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0
+X-Zenbin-Recipient-Key-Id: HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0
 \`\`\`
 
 HTML pages include:
 
 \`\`\`html
-<meta name="cap:recipient-key-id" content="agent-bob-456">
+<meta name="cap:recipient-key-id" content="HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0">
 \`\`\`
 
-JSON metadata (\`Accept: application/json\`) includes \`recipientKeyId\`.
+JSON metadata (\`Accept: application/json\`) includes \`recipientKeyId\` and the authenticated key's \`publicKeyFingerprint\`.
 
 ### Deleting a page
 

--- a/src/docs/agentSetupInstructions.ts
+++ b/src/docs/agentSetupInstructions.ts
@@ -41,11 +41,12 @@ const privateJwk = privateKey.export({ format: 'jwk' });
 console.log(JSON.stringify({ keyId, publicJwk, privateJwk }, null, 2));
 \`\`\`
 
-Save the output — you need all three values: \`keyId\`, \`publicJwk\`, and \`privateJwk\`.
+Save the output — you need all four values: \`keyId\`, \`publicJwk\`, \`privateJwk\`, and \`publicKeyFingerprint\`.
 
 **Important:**
 - The **private JWK** stays local. Use it to sign every publish request.
 - The **public JWK** gets registered with ZenBin in the next step.
+- The **public key fingerprint** (43-char base64url string) is the SHA-256 hash of your Ed25519 public key. It's used as \`recipientKeyId\` when directing content to specific agents.
 - Never share the private JWK.
 
 ## Step 2: Register your public key
@@ -68,7 +69,7 @@ curl -X POST ${config.baseUrl}/v1/keys/register \\
 You should get back:
 
 \`\`\`json
-{"keyId":"your-key-id","status":"active","scopes":[],"created_at":"...","updated_at":"..."}
+{"keyId":"your-key-id","publicKeyFingerprint":"HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0","status":"active","scopes":[],"created_at":"...","updated_at":"..."}
 \`\`\`
 
 ## Step 3: Sign and publish a page

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { cors } from 'hono/cors';
 import { logger } from 'hono/logger';
 import dotenv from 'dotenv';
 import { config } from './config.js';
-import { initDatabase, closeDatabase, backfillOwnerIndex, backfillRecipientIndex } from './storage/db.js';
+import { initDatabase, closeDatabase, backfillOwnerIndex, backfillRecipientIndex, backfillKeyFingerprints } from './storage/db.js';
 import { initVideoStorage } from './storage/video.js';
 import { createServices, type Services } from './services/container.js';
 import { pages } from './routes/pages.js';
@@ -219,6 +219,12 @@ async function main() {
     const recipientBackfillResult = backfillRecipientIndex();
     if (recipientBackfillResult.indexed > 0 || recipientBackfillResult.skipped > 0) {
       console.log(`Recipient index backfill: ${recipientBackfillResult.indexed} indexed, ${recipientBackfillResult.skipped} skipped (no recipientKeyId)`);
+    }
+
+    // Backfill publicKeyFingerprint for keys that don't have one
+    const fpResult = backfillKeyFingerprints();
+    if (fpResult.updated > 0 || fpResult.skipped > 0) {
+      console.log(`Key fingerprint backfill: ${fpResult.updated} updated, ${fpResult.skipped} skipped (already have fingerprint)`);
     }
 
     console.log('Initializing video storage...');

--- a/src/routes/keys.ts
+++ b/src/routes/keys.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import { validateEd25519PublicJwk } from '../utils/httpSignature.js';
+import { computeFingerprint } from '../utils/fingerprint.js';
 import { ErrorCodes, errorResponse } from '../errors.js';
 import type { Services } from '../services/container.js';
 
@@ -55,6 +56,7 @@ keys.post('/register', async (c) => {
   const key = await services.keys.save({
     keyId: trimmedKeyId,
     publicJwk: body.publicJwk,
+    publicKeyFingerprint: computeFingerprint(body.publicJwk as { x: string }),
     scopes: [],
     status: 'active',
   });
@@ -71,6 +73,7 @@ keys.post('/register', async (c) => {
 
   return c.json({
     keyId: key.keyId,
+    publicKeyFingerprint: key.publicKeyFingerprint,
     status: key.status,
     scopes: key.scopes,
     created_at: key.created_at,
@@ -95,6 +98,7 @@ keys.get('/:keyId/jwk', (c) => {
   return c.json({
     keyId: agentKey.keyId,
     publicJwk: agentKey.publicJwk,
+    publicKeyFingerprint: agentKey.publicKeyFingerprint,
     status: agentKey.status,
     created_at: agentKey.created_at,
   });

--- a/src/routes/pages.ts
+++ b/src/routes/pages.ts
@@ -5,6 +5,7 @@ import { hasScope, requireSignedAgent, requireSignedAgentForGet } from '../middl
 import { checkPageLimit, getPlanFromKey, isBillingCycleExpired } from '../rules.js';
 import { ErrorCodes, errorResponse } from '../errors.js';
 import { generateEtag } from '../utils/etag.js';
+import { isValidFingerprint } from '../utils/fingerprint.js';
 import { generateUrlToken, hashPassword, parseBasicAuth, verifyPassword } from '../utils/auth.js';
 import { decodeHtml, decodeMarkdown, validateAuthInput, validateId, validatePageBody } from '../utils/validation.js';
 import { trackApiCall, trackPageCreated, trackPageDeleted, trackPageUpdated } from '../analytics/posthog.js';
@@ -47,7 +48,9 @@ pages.use('*', requireSignedAgent);
 
 // GET /v1/pages — List pages owned by or directed to the authenticated key
 pages.get('/', requireSignedAgentForGet, (c) => {
-  const keyId = getSignedKey(c);
+  const signedAgent = c.get('signedAgent');
+  const keyId = signedAgent?.key?.keyId || getSignedKey(c);
+  const keyFingerprint = signedAgent?.key?.publicKeyFingerprint;
   const services = getServices(c);
   const cursor = c.req.query('cursor');
   const limitParam = c.req.query('limit');
@@ -57,7 +60,9 @@ pages.get('/', requireSignedAgentForGet, (c) => {
 
   let result;
   if (recipientParam === 'me') {
-    result = services.pages.listByRecipient(keyId, cursor, limit, since);
+    // recipient=me resolves to the authenticated key's fingerprint
+    const recipientFingerprint = keyFingerprint || keyId;
+    result = services.pages.listByRecipient(recipientFingerprint, cursor, limit, since);
   } else {
     result = services.pages.listByOwner(keyId, cursor, limit, since);
   }
@@ -301,6 +306,11 @@ pages.post('/:id', async (c) => {
   } else {
     // Neither provided: keep existing value
     recipientKeyId = undefined;
+  }
+
+  // Validate recipientKeyId is a 43-char base64url fingerprint (when present)
+  if (recipientKeyId && !isValidFingerprint(recipientKeyId)) {
+    return errorResponse(ErrorCodes.INVALID_REQUEST, 'recipientKeyId must be a 43-character base64url public key fingerprint (SHA-256 of the Ed25519 public key)', 400);
   }
 
   const { page, created } = await services.pages.save(

--- a/src/services/interfaces.ts
+++ b/src/services/interfaces.ts
@@ -94,6 +94,7 @@ export interface IKeyService {
   save(input: {
     keyId: string;
     publicJwk: AgentKey['publicJwk'];
+    publicKeyFingerprint?: string;
     scopes?: string[];
     status?: AgentKey['status'];
     plan?: Plan;

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto';
 import { open, Database } from 'lmdb';
 import { config } from '../config.js';
 import type {
@@ -146,6 +147,42 @@ export function backfillOwnerIndex(): { indexed: number; skipped: number } {
   }
 
   return { indexed, skipped };
+}
+
+/**
+ * Backfill publicKeyFingerprint for existing keys that don't have one.
+ * Called once after database initialization.
+ */
+export function backfillKeyFingerprints(): { updated: number; skipped: number } {
+  const keysDb = getAgentKeyDatabase();
+  let updated = 0;
+  let skipped = 0;
+
+  for (const keyId of keysDb.getKeys()) {
+    const key = keysDb.get(keyId);
+    if (!key) continue;
+
+    if (key.publicKeyFingerprint) {
+      skipped++;
+      continue;
+    }
+
+    // Compute fingerprint from public JWK
+    const x = key.publicJwk?.x;
+    if (!x || typeof x !== 'string') {
+      skipped++;
+      continue;
+    }
+
+    const pubKeyBuf = Buffer.from(x as string, 'base64url');
+    const fingerprint = crypto.createHash('sha256').update(pubKeyBuf).digest('base64url');
+
+    key.publicKeyFingerprint = fingerprint;
+    keysDb.putSync(keyId, key);
+    updated++;
+  }
+
+  return { updated, skipped };
 }
 
 /**
@@ -485,6 +522,7 @@ export function decrementSubdomainPageCount(name: string): void {
 export async function saveAgentKey(input: {
   keyId: string;
   publicJwk: AgentKey['publicJwk'];
+  publicKeyFingerprint?: string;
   scopes?: string[];
   status?: AgentKey['status'];
   plan?: Plan;
@@ -494,6 +532,7 @@ export async function saveAgentKey(input: {
   const record: AgentKey = {
     keyId: input.keyId,
     publicJwk: input.publicJwk,
+    publicKeyFingerprint: input.publicKeyFingerprint || existing?.publicKeyFingerprint || '',
     scopes: input.scopes || existing?.scopes || [],
     status: input.status || existing?.status || 'active',
     created_at: existing?.created_at || now,

--- a/src/test/api.test.ts
+++ b/src/test/api.test.ts
@@ -80,10 +80,12 @@ describe('POST /v1/keys/register', () => {
     });
 
     expect(res.status).toBe(201);
-    const payload = await res.json() as { keyId: string; status: string; scopes: string[] };
+    const payload = await res.json() as { keyId: string; status: string; scopes: string[]; publicKeyFingerprint: string };
     expect(payload.keyId).toBe(keyId);
     expect(payload.status).toBe('active');
     expect(payload.scopes).toEqual([]);
+    expect(payload.publicKeyFingerprint).toHaveLength(43);
+    expect(payload.publicKeyFingerprint).toMatch(/^[A-Za-z0-9_-]+$/);
   });
 
   it('should allow a self-registered key to publish content', async () => {
@@ -114,6 +116,27 @@ describe('POST /v1/keys/register', () => {
     });
 
     expect(publishRes.status).toBe(201);
+  });
+
+  it('should return publicKeyFingerprint on GET /:keyId/jwk', async () => {
+    const keyId = uniqueId('jwk-fp');
+    const signerMaterial = generateTestSigner(keyId);
+
+    const regRes = await app.request('/v1/keys/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        keyId,
+        publicJwk: signerMaterial.publicJwk,
+      }),
+    });
+    expect(regRes.status).toBe(201);
+
+    const jwkRes = await app.request(`/v1/keys/${encodeURIComponent(keyId)}/jwk`);
+    expect(jwkRes.status).toBe(200);
+    const data = await jwkRes.json() as any;
+    expect(data.publicKeyFingerprint).toHaveLength(43);
+    expect(data.publicKeyFingerprint).toMatch(/^[A-Za-z0-9_-]+$/);
   });
 
   it('should reject invalid public JWKs', async () => {

--- a/src/test/cap-recipient.test.ts
+++ b/src/test/cap-recipient.test.ts
@@ -87,13 +87,26 @@ describe('Phase 1: Data Model + Storage', () => {
     expect(page.recipientKeyId).toBeUndefined();
   });
 
+  it('should reject invalid recipientKeyId format on publish', async () => {
+    const id = uniqueId('invalid-recipient');
+    const res = await app.request(`/v1/pages/${id}`, jsonSignedRequest({
+      signer: alice,
+      method: 'POST',
+      path: `/v1/pages/${id}`,
+      body: { html: '<h1>Bad Recipient</h1>', recipientKeyId: 'agent-bob-456' },
+    }));
+    expect(res.status).toBe(400);
+    const data = await res.json() as any;
+    expect(data.error).toContain('fingerprint');
+  });
+
   it('should create and query recipient index entries', async () => {
     const id = uniqueId('recipient-idx');
     const res = await app.request(`/v1/pages/${id}`, jsonSignedRequest({
       signer: alice,
       method: 'POST',
       path: `/v1/pages/${id}`,
-      body: { html: '<h1>Recipient Index Test</h1>', recipientKeyId: bob.keyId },
+      body: { html: '<h1>Recipient Index Test</h1>', recipientKeyId: bob.publicKeyFingerprint },
     }));
     expect(res.status).toBe(201);
 
@@ -110,7 +123,7 @@ describe('Phase 1: Data Model + Storage', () => {
       signer: alice,
       method: 'POST',
       path: `/v1/pages/${id}`,
-      body: { html: '<h1>To Delete</h1>', recipientKeyId: bob.keyId },
+      body: { html: '<h1>To Delete</h1>', recipientKeyId: bob.publicKeyFingerprint },
     }));
 
     // Verify Bob can see it
@@ -144,7 +157,7 @@ describe('Phase 1: Data Model + Storage', () => {
         signer: alice,
         method: 'POST',
         path: `/v1/pages/${id}`,
-        body: { html: `<h1>${id}</h1>`, recipientKeyId: bob.keyId },
+        body: { html: `<h1>${id}</h1>`, recipientKeyId: bob.publicKeyFingerprint },
       }));
       // Small delay to ensure different timestamps
       await new Promise(r => setTimeout(r, 10));
@@ -178,7 +191,7 @@ describe('Phase 1: Data Model + Storage', () => {
       signer: alice,
       method: 'POST',
       path: `/v1/pages/${id}`,
-      body: { html: '<h1>Since Filter</h1>', recipientKeyId: bob.keyId },
+      body: { html: '<h1>Since Filter</h1>', recipientKeyId: bob.publicKeyFingerprint },
     }));
 
     const listRes = await app.request(signedGet(bob, `/v1/pages?recipient=me&since=${encodeURIComponent(since)}`));
@@ -213,11 +226,11 @@ describe('Phase 2: Publish + Query', () => {
       signer: alice,
       method: 'POST',
       path: `/v1/pages/${id}`,
-      body: { html: '<h1>Body Recipient</h1>', recipientKeyId: bob.keyId },
+      body: { html: '<h1>Body Recipient</h1>', recipientKeyId: bob.publicKeyFingerprint },
     }));
     expect(res.status).toBe(201);
     const data = await res.json() as any;
-    expect(data.recipientKeyId).toBe(bob.keyId);
+    expect(data.recipientKeyId).toBe(bob.publicKeyFingerprint);
   });
 
   it('should store recipient from CAP-Recipient-Key-Id header', async () => {
@@ -227,11 +240,11 @@ describe('Phase 2: Publish + Query', () => {
       method: 'POST',
       path: `/v1/pages/${id}`,
       body: { html: '<h1>CAP Header</h1>' },
-      headers: { 'CAP-Recipient-Key-Id': bob.keyId },
+      headers: { 'CAP-Recipient-Key-Id': bob.publicKeyFingerprint },
     }));
     expect(res.status).toBe(201);
     const data = await res.json() as any;
-    expect(data.recipientKeyId).toBe(bob.keyId);
+    expect(data.recipientKeyId).toBe(bob.publicKeyFingerprint);
   });
 
   it('should store recipient from X-Zenbin-Recipient-Key-Id header (legacy)', async () => {
@@ -241,11 +254,11 @@ describe('Phase 2: Publish + Query', () => {
       method: 'POST',
       path: `/v1/pages/${id}`,
       body: { html: '<h1>ZenBin Header</h1>' },
-      headers: { 'X-Zenbin-Recipient-Key-Id': bob.keyId },
+      headers: { 'X-Zenbin-Recipient-Key-Id': bob.publicKeyFingerprint },
     }));
     expect(res.status).toBe(201);
     const data = await res.json() as any;
-    expect(data.recipientKeyId).toBe(bob.keyId);
+    expect(data.recipientKeyId).toBe(bob.publicKeyFingerprint);
   });
 
   it('should give CAP header priority over body field', async () => {
@@ -254,12 +267,12 @@ describe('Phase 2: Publish + Query', () => {
       signer: alice,
       method: 'POST',
       path: `/v1/pages/${id}`,
-      body: { html: '<h1>Priority</h1>', recipientKeyId: 'body-value' },
-      headers: { 'CAP-Recipient-Key-Id': 'header-value' },
+      body: { html: '<h1>Priority</h1>', recipientKeyId: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' },
+      headers: { 'CAP-Recipient-Key-Id': 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB' },
     }));
     expect(res.status).toBe(201);
     const data = await res.json() as any;
-    expect(data.recipientKeyId).toBe('header-value');
+    expect(data.recipientKeyId).toBe('BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB');
   });
 
   it('should create undirected page without recipientKeyId', async () => {
@@ -290,11 +303,11 @@ describe('Phase 2: Publish + Query', () => {
       signer: alice,
       method: 'POST',
       path: `/v1/pages/${id}`,
-      body: { html: '<h1>Add Recipient Updated</h1>', recipientKeyId: bob.keyId },
+      body: { html: '<h1>Add Recipient Updated</h1>', recipientKeyId: bob.publicKeyFingerprint },
     }));
     expect(res.status).toBe(200);
     const data = await res.json() as any;
-    expect(data.recipientKeyId).toBe(bob.keyId);
+    expect(data.recipientKeyId).toBe(bob.publicKeyFingerprint);
 
     // Verify Bob can see it
     const listRes = await app.request(signedGet(bob, '/v1/pages?recipient=me'));
@@ -309,7 +322,7 @@ describe('Phase 2: Publish + Query', () => {
       signer: alice,
       method: 'POST',
       path: `/v1/pages/${id}`,
-      body: { html: '<h1>Change Recipient</h1>', recipientKeyId: bob.keyId },
+      body: { html: '<h1>Change Recipient</h1>', recipientKeyId: bob.publicKeyFingerprint },
     }));
 
     // Change recipient to Carol
@@ -317,7 +330,7 @@ describe('Phase 2: Publish + Query', () => {
       signer: alice,
       method: 'POST',
       path: `/v1/pages/${id}`,
-      body: { html: '<h1>Changed to Carol</h1>', recipientKeyId: carol.keyId },
+      body: { html: '<h1>Changed to Carol</h1>', recipientKeyId: carol.publicKeyFingerprint },
     }));
 
     // Bob should no longer see it
@@ -338,7 +351,7 @@ describe('Phase 2: Publish + Query', () => {
       signer: alice,
       method: 'POST',
       path: `/v1/pages/${id}`,
-      body: { html: '<h1>Remove Recipient</h1>', recipientKeyId: bob.keyId },
+      body: { html: '<h1>Remove Recipient</h1>', recipientKeyId: bob.publicKeyFingerprint },
     }));
 
     // Remove recipient (set to empty string → treated as undefined)
@@ -365,24 +378,24 @@ describe('Phase 2: Publish + Query', () => {
       signer: alice,
       method: 'POST',
       path: `/v1/pages/${id1}`,
-      body: { html: '<h1>To Bob 1</h1>', recipientKeyId: bob.keyId },
+      body: { html: '<h1>To Bob 1</h1>', recipientKeyId: bob.publicKeyFingerprint },
     }));
     await app.request(`/v1/pages/${id2}`, jsonSignedRequest({
       signer: alice,
       method: 'POST',
       path: `/v1/pages/${id2}`,
-      body: { html: '<h1>To Bob 2</h1>', recipientKeyId: bob.keyId },
+      body: { html: '<h1>To Bob 2</h1>', recipientKeyId: bob.publicKeyFingerprint },
     }));
     await app.request(`/v1/pages/${id3}`, jsonSignedRequest({
       signer: alice,
       method: 'POST',
       path: `/v1/pages/${id3}`,
-      body: { html: '<h1>To Carol</h1>', recipientKeyId: carol.keyId },
+      body: { html: '<h1>To Carol</h1>', recipientKeyId: carol.publicKeyFingerprint },
     }));
 
     const listRes = await app.request(signedGet(bob, '/v1/pages?recipient=me'));
     const data = await listRes.json() as any;
-    expect(data.pages.every((p: any) => p.recipientKeyId === bob.keyId)).toBe(true);
+    expect(data.pages.every((p: any) => p.recipientKeyId === bob.publicKeyFingerprint)).toBe(true);
     expect(data.pages.some((p: any) => p.id === id3)).toBe(false);
   });
 
@@ -401,7 +414,7 @@ describe('Phase 2: Publish + Query', () => {
       signer: alice,
       method: 'POST',
       path: `/v1/pages/${id}`,
-      body: { html: '<h1>Cross Subdomain</h1>', recipientKeyId: bob.keyId },
+      body: { html: '<h1>Cross Subdomain</h1>', recipientKeyId: bob.publicKeyFingerprint },
       headers: { 'X-Subdomain': subdomain },
     }));
 
@@ -427,7 +440,7 @@ describe('Phase 2: Publish + Query', () => {
       signer: alice,
       method: 'POST',
       path: `/v1/pages/${id2}`,
-      body: { html: '<h1>Alice to Bob</h1>', recipientKeyId: bob.keyId },
+      body: { html: '<h1>Alice to Bob</h1>', recipientKeyId: bob.publicKeyFingerprint },
     }));
 
     // Owner query should return both
@@ -457,17 +470,19 @@ describe('Phase 2: Publish + Query', () => {
     expect(data.recipientKeyId).toBeUndefined();
   });
 
-  it('should accept non-existent keyId as recipient', async () => {
-    const id = uniqueId('nonexistent-recipient');
+  it('should accept valid fingerprint as recipient even for unregistered key', async () => {
+    const id = uniqueId('unregistered-recipient');
+    // A valid 43-char base64url fingerprint that doesn't belong to any registered key
+    const unregisteredFingerprint = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
     const res = await app.request(`/v1/pages/${id}`, jsonSignedRequest({
       signer: alice,
       method: 'POST',
       path: `/v1/pages/${id}`,
-      body: { html: '<h1>Nonexistent Recipient</h1>', recipientKeyId: 'agent-nonexistent-456' },
+      body: { html: '<h1>Unregistered Recipient</h1>', recipientKeyId: unregisteredFingerprint },
     }));
     expect(res.status).toBe(201);
     const data = await res.json() as any;
-    expect(data.recipientKeyId).toBe('agent-nonexistent-456');
+    expect(data.recipientKeyId).toBe(unregisteredFingerprint);
   });
 
   it('should clean up recipient index on page delete', async () => {
@@ -476,7 +491,7 @@ describe('Phase 2: Publish + Query', () => {
       signer: alice,
       method: 'POST',
       path: `/v1/pages/${id}`,
-      body: { html: '<h1>Delete Me</h1>', recipientKeyId: bob.keyId },
+      body: { html: '<h1>Delete Me</h1>', recipientKeyId: bob.publicKeyFingerprint },
     }));
 
     // Bob sees it
@@ -506,11 +521,11 @@ describe('Phase 3: Provenance', () => {
       signer: alice,
       method: 'POST',
       path: `/v1/pages/${id}`,
-      body: { html: '<h1>Provenance CAP</h1>', recipientKeyId: bob.keyId },
+      body: { html: '<h1>Provenance CAP</h1>', recipientKeyId: bob.publicKeyFingerprint },
     }));
 
     const res = await app.request(`/p/${id}`);
-    expect(res.headers.get('CAP-Recipient-Key-Id')).toBe(bob.keyId);
+    expect(res.headers.get('CAP-Recipient-Key-Id')).toBe(bob.publicKeyFingerprint);
   });
 
   it('should include X-Zenbin-Recipient-Key-Id response header', async () => {
@@ -519,11 +534,11 @@ describe('Phase 3: Provenance', () => {
       signer: alice,
       method: 'POST',
       path: `/v1/pages/${id}`,
-      body: { html: '<h1>Provenance ZenBin</h1>', recipientKeyId: bob.keyId },
+      body: { html: '<h1>Provenance ZenBin</h1>', recipientKeyId: bob.publicKeyFingerprint },
     }));
 
     const res = await app.request(`/p/${id}`);
-    expect(res.headers.get('X-Zenbin-Recipient-Key-Id')).toBe(bob.keyId);
+    expect(res.headers.get('X-Zenbin-Recipient-Key-Id')).toBe(bob.publicKeyFingerprint);
   });
 
   it('should omit recipient headers when page has no recipient', async () => {
@@ -546,12 +561,12 @@ describe('Phase 3: Provenance', () => {
       signer: alice,
       method: 'POST',
       path: `/v1/pages/${id}`,
-      body: { html: '<html><head></head><body><h1>Meta Tag Test</h1></body></html>', recipientKeyId: bob.keyId },
+      body: { html: '<html><head></head><body><h1>Meta Tag Test</h1></body></html>', recipientKeyId: bob.publicKeyFingerprint },
     }));
 
     const res = await app.request(`/p/${id}`);
     const html = await res.text();
-    expect(html).toContain(`name="cap:recipient-key-id" content="${bob.keyId}"`);
+    expect(html).toContain(`name="cap:recipient-key-id" content="${bob.publicKeyFingerprint}"`);
   });
 
   it('should include recipientKeyId in JSON metadata', async () => {
@@ -560,14 +575,14 @@ describe('Phase 3: Provenance', () => {
       signer: alice,
       method: 'POST',
       path: `/v1/pages/${id}`,
-      body: { html: '<h1>JSON Meta</h1>', recipientKeyId: bob.keyId },
+      body: { html: '<h1>JSON Meta</h1>', recipientKeyId: bob.publicKeyFingerprint },
     }));
 
     const res = await app.request(`/p/${id}`, {
       headers: { Accept: 'application/json' },
     });
     const data = await res.json() as any;
-    expect(data.recipientKeyId).toBe(bob.keyId);
+    expect(data.recipientKeyId).toBe(bob.publicKeyFingerprint);
   });
 
   it('should include recipientKeyId in page list summary', async () => {
@@ -576,14 +591,14 @@ describe('Phase 3: Provenance', () => {
       signer: alice,
       method: 'POST',
       path: `/v1/pages/${id}`,
-      body: { html: '<h1>List Summary</h1>', recipientKeyId: bob.keyId },
+      body: { html: '<h1>List Summary</h1>', recipientKeyId: bob.publicKeyFingerprint },
     }));
 
     const listRes = await app.request(signedGet(bob, '/v1/pages?recipient=me'));
     const data = await listRes.json() as any;
     const found = data.pages.find((p: any) => p.id === id);
     expect(found).toBeDefined();
-    expect(found.recipientKeyId).toBe(bob.keyId);
+    expect(found.recipientKeyId).toBe(bob.publicKeyFingerprint);
   });
 
   it('should include recipientKeyId in owner page list', async () => {
@@ -592,14 +607,14 @@ describe('Phase 3: Provenance', () => {
       signer: alice,
       method: 'POST',
       path: `/v1/pages/${id}`,
-      body: { html: '<h1>Owner List</h1>', recipientKeyId: bob.keyId },
+      body: { html: '<h1>Owner List</h1>', recipientKeyId: bob.publicKeyFingerprint },
     }));
 
     const listRes = await app.request(signedGet(alice, '/v1/pages'));
     const data = await listRes.json() as any;
     const found = data.pages.find((p: any) => p.id === id);
     expect(found).toBeDefined();
-    expect(found.recipientKeyId).toBe(bob.keyId);
+    expect(found.recipientKeyId).toBe(bob.publicKeyFingerprint);
   });
 
   it('should include recipientKeyId in publish response', async () => {
@@ -608,11 +623,11 @@ describe('Phase 3: Provenance', () => {
       signer: alice,
       method: 'POST',
       path: `/v1/pages/${id}`,
-      body: { html: '<h1>Publish Response</h1>', recipientKeyId: bob.keyId },
+      body: { html: '<h1>Publish Response</h1>', recipientKeyId: bob.publicKeyFingerprint },
     }));
     expect(res.status).toBe(201);
     const data = await res.json() as any;
-    expect(data.recipientKeyId).toBe(bob.keyId);
+    expect(data.recipientKeyId).toBe(bob.publicKeyFingerprint);
   });
 
   it('should include both CAP and X-Zenbin headers consistently', async () => {
@@ -621,12 +636,12 @@ describe('Phase 3: Provenance', () => {
       signer: alice,
       method: 'POST',
       path: `/v1/pages/${id}`,
-      body: { html: '<h1>Dual Headers</h1>', recipientKeyId: bob.keyId },
+      body: { html: '<h1>Dual Headers</h1>', recipientKeyId: bob.publicKeyFingerprint },
     }));
 
     const res = await app.request(`/p/${id}`);
-    expect(res.headers.get('CAP-Recipient-Key-Id')).toBe(bob.keyId);
-    expect(res.headers.get('X-Zenbin-Recipient-Key-Id')).toBe(bob.keyId);
+    expect(res.headers.get('CAP-Recipient-Key-Id')).toBe(bob.publicKeyFingerprint);
+    expect(res.headers.get('X-Zenbin-Recipient-Key-Id')).toBe(bob.publicKeyFingerprint);
   });
 });
 
@@ -640,7 +655,7 @@ describe('Phase 5: Integration Tests', () => {
       signer: alice,
       method: 'POST',
       path: `/v1/pages/${id}`,
-      body: { html: '<h1>Task Results</h1>', recipientKeyId: bob.keyId },
+      body: { html: '<h1>Task Results</h1>', recipientKeyId: bob.publicKeyFingerprint },
     }));
 
     // Bob queries ?recipient=me — sees the page
@@ -651,7 +666,7 @@ describe('Phase 5: Integration Tests', () => {
     // Bob reads the page — sees recipientKeyId in headers and metadata
     const pageRes = await app.request(`/p/${id}`, { headers: { Accept: 'application/json' } });
     const pageData = await pageRes.json() as any;
-    expect(pageData.recipientKeyId).toBe(bob.keyId);
+    expect(pageData.recipientKeyId).toBe(bob.publicKeyFingerprint);
 
     // Alice queries ?recipient=me — does NOT see the page (she owns it)
     listRes = await app.request(signedGet(alice, '/v1/pages?recipient=me'));
@@ -673,7 +688,7 @@ describe('Phase 5: Integration Tests', () => {
       signer: alice,
       method: 'POST',
       path: `/v1/pages/${id1}`,
-      body: { html: '<h1>First</h1>', recipientKeyId: bob.keyId },
+      body: { html: '<h1>First</h1>', recipientKeyId: bob.publicKeyFingerprint },
     }));
 
     await new Promise(r => setTimeout(r, 50));
@@ -685,7 +700,7 @@ describe('Phase 5: Integration Tests', () => {
       signer: alice,
       method: 'POST',
       path: `/v1/pages/${id2}`,
-      body: { html: '<h1>Second</h1>', recipientKeyId: bob.keyId },
+      body: { html: '<h1>Second</h1>', recipientKeyId: bob.publicKeyFingerprint },
     }));
 
     // since=T1 → both pages
@@ -727,7 +742,7 @@ describe('Phase 5: Integration Tests', () => {
       signer: alice,
       method: 'POST',
       path: `/v1/pages/${id}`,
-      body: { html: '<h1>Reassign</h1>', recipientKeyId: bob.keyId },
+      body: { html: '<h1>Reassign</h1>', recipientKeyId: bob.publicKeyFingerprint },
     }));
 
     // Bob sees it
@@ -740,7 +755,7 @@ describe('Phase 5: Integration Tests', () => {
       signer: alice,
       method: 'POST',
       path: `/v1/pages/${id}`,
-      body: { html: '<h1>Reassigned to Carol</h1>', recipientKeyId: carol.keyId },
+      body: { html: '<h1>Reassigned to Carol</h1>', recipientKeyId: carol.publicKeyFingerprint },
     }));
 
     // Bob no longer sees it
@@ -760,7 +775,7 @@ describe('Phase 5: Integration Tests', () => {
       signer: alice,
       method: 'POST',
       path: `/v1/pages/${id}`,
-      body: { html: '<h1>Will Lose Recipient</h1>', recipientKeyId: bob.keyId },
+      body: { html: '<h1>Will Lose Recipient</h1>', recipientKeyId: bob.publicKeyFingerprint },
     }));
 
     // Bob sees it
@@ -792,7 +807,7 @@ describe('Phase 5: Integration Tests', () => {
       signer: alice,
       method: 'POST',
       path: `/v1/pages/${id}`,
-      body: { html: '<h1>Verify Me</h1>', recipientKeyId: bob.keyId },
+      body: { html: '<h1>Verify Me</h1>', recipientKeyId: bob.publicKeyFingerprint },
     }));
 
     // Verify recipientKeyId is in the JSON metadata (recipientKeyId is NOT part of signature verification)
@@ -800,7 +815,7 @@ describe('Phase 5: Integration Tests', () => {
       headers: { Accept: 'application/json' },
     });
     const pageData = await pageRes.json() as any;
-    expect(pageData.recipientKeyId).toBe(bob.keyId);
+    expect(pageData.recipientKeyId).toBe(bob.publicKeyFingerprint);
     expect(pageData.capVersion).toBe('0.1');
   });
 
@@ -837,7 +852,7 @@ describe('Phase 5: Integration Tests', () => {
       signer: alice,
       method: 'POST',
       path: `/v1/pages/${id}`,
-      body: { html: '<h1>Delete Me</h1>', recipientKeyId: bob.keyId },
+      body: { html: '<h1>Delete Me</h1>', recipientKeyId: bob.publicKeyFingerprint },
     }));
 
     // Bob sees it

--- a/src/test/fingerprint.test.ts
+++ b/src/test/fingerprint.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { computeFingerprint, isValidFingerprint } from '../utils/fingerprint.js';
+
+describe('Fingerprint Utility', () => {
+  it('should compute a 43-char base64url fingerprint from an Ed25519 JWK', () => {
+    // Real Ed25519 public key (x field is 43 chars base64url)
+    const publicJwk = {
+      kty: 'OKP',
+      crv: 'Ed25519',
+      x: '11qYAYKxCrfVS_7kOfsSVBJE8D7A7LJW8DT6JVC-AgY',
+    };
+    const fp = computeFingerprint(publicJwk);
+    expect(fp).toHaveLength(43);
+    expect(isValidFingerprint(fp)).toBe(true);
+    // Should only contain base64url chars
+    expect(fp).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it('should produce the same fingerprint for the same key', () => {
+    const publicJwk = {
+      kty: 'OKP',
+      crv: 'Ed25519',
+      x: '11qYAYKxCrfVS_7kOfsSVBJE8D7A7LJW8DT6JVC-AgY',
+    };
+    const fp1 = computeFingerprint(publicJwk);
+    const fp2 = computeFingerprint(publicJwk);
+    expect(fp1).toBe(fp2);
+  });
+
+  it('should produce different fingerprints for different keys', () => {
+    const key1 = { kty: 'OKP', crv: 'Ed25519', x: '11qYAYKxCrfVS_7kOfsSVBJE8D7A7LJW8DT6JVC-AgY' };
+    const key2 = { kty: 'OKP', crv: 'Ed25519', x: '22qYAYKxCrfVS_7kOfsSVBJE8D7A7LJW8DT6JVC-AgY' };
+    expect(computeFingerprint(key1)).not.toBe(computeFingerprint(key2));
+  });
+
+  it('should reject invalid fingerprints', () => {
+    expect(isValidFingerprint('')).toBe(false);
+    expect(isValidFingerprint('too-short')).toBe(false);
+    expect(isValidFingerprint('this-is-exactly-43-chars-but-has+invalid=chars!')).toBe(false);
+    expect(isValidFingerprint('agent-bob-456')).toBe(false);
+  });
+
+  it('should accept valid 43-char base64url strings', () => {
+    expect(isValidFingerprint('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')).toBe(true);
+    expect(isValidFingerprint('HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0')).toBe(true);
+  });
+});

--- a/src/test/helpers/signing.ts
+++ b/src/test/helpers/signing.ts
@@ -1,22 +1,26 @@
 import { createHash, generateKeyPairSync, sign } from 'crypto';
 import { saveAgentKey } from '../../storage/db.js';
+import { computeFingerprint } from '../../utils/fingerprint.js';
 
 export interface TestSigner {
   keyId: string;
   publicJwk: Record<string, string | boolean | undefined>;
   privateJwk: Record<string, string | boolean | undefined>;
+  /** SHA-256 fingerprint of the Ed25519 public key (43-char base64url) */
+  publicKeyFingerprint: string;
 }
 
 export function generateTestSigner(keyId: string): TestSigner {
   const { publicKey, privateKey } = generateKeyPairSync('ed25519');
   const publicJwk = publicKey.export({ format: 'jwk' }) as Record<string, string | boolean | undefined>;
   const privateJwk = privateKey.export({ format: 'jwk' }) as Record<string, string | boolean | undefined>;
-  return { keyId, publicJwk, privateJwk };
+  const publicKeyFingerprint = computeFingerprint(publicJwk as { x: string });
+  return { keyId, publicJwk, privateJwk, publicKeyFingerprint };
 }
 
 export async function createTestSigner(keyId: string, scopes: string[] = []): Promise<TestSigner> {
   const signer = generateTestSigner(keyId);
-  await saveAgentKey({ keyId, publicJwk: signer.publicJwk, scopes });
+  await saveAgentKey({ keyId, publicJwk: signer.publicJwk, publicKeyFingerprint: signer.publicKeyFingerprint, scopes });
   return signer;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,6 +83,8 @@ export interface Subdomain {
 export interface AgentKey {
   keyId: string;
   publicJwk: StoredJwk;
+  /** SHA-256 of the Ed25519 public key, base64url-encoded (43 chars). Derived from publicJwk.x at registration. */
+  publicKeyFingerprint: string;
   status: 'active' | 'blocked' | 'revoked';
   scopes: string[];
   created_at: string;

--- a/src/utils/fingerprint.ts
+++ b/src/utils/fingerprint.ts
@@ -1,0 +1,19 @@
+import crypto from 'node:crypto';
+
+/**
+ * Compute the public key fingerprint from an Ed25519 JWK.
+ * SHA-256 of the decoded 'x' field, base64url-encoded.
+ * Always 43 characters. Globally unique per key.
+ */
+export function computeFingerprint(publicJwk: { x: string }): string {
+  const pubKeyBuf = Buffer.from(publicJwk.x, 'base64url');
+  return crypto.createHash('sha256').update(pubKeyBuf).digest('base64url');
+}
+
+/**
+ * Validate that a string looks like a public key fingerprint.
+ * Must be exactly 43 base64url characters.
+ */
+export function isValidFingerprint(value: string): boolean {
+  return /^[A-Za-z0-9_-]{43}$/.test(value);
+}


### PR DESCRIPTION
Breaking change: recipientKeyId must be 43-char base64url fingerprint. See docs/specs/cap-recipient-v0.2.1.md for full spec.