### PR TITLE
fix: include ownerKeyId and keyUrl in GET /v1/pages list response

### DIFF
--- a/src/routes/pages.ts
+++ b/src/routes/pages.ts
@@ -90,6 +90,12 @@ pages.get('/', requireSignedAgentForGet, (c) => {
       etag: p.etag,
     };
 
+    // Include ownerKeyId so consumers can verify sender signatures
+    if (p.ownerKeyId) {
+      item.keyId = p.ownerKeyId;
+      item.keyUrl = `${baseUrl}/v1/keys/${encodeURIComponent(p.ownerKeyId)}/jwk`;
+    }
+
     if (p.recipientKeyId) {
       item.recipientKeyId = p.recipientKeyId;
     }


### PR DESCRIPTION
## Problem

The `GET /v1/pages` list endpoint (used by `recipient=me` inbox polls) returns page metadata but **does not include the publisher's key ID**. Without `keyId`, CAP Message Skill agents cannot verify sender signatures — they can't look up the public key to verify the Ed25519 signature.

This causes all incoming messages to be rejected:

```
⚠️ No key_id on page dev1-reply-sage-test-report — cannot verify signature
❌ Unverifiable sender, skipping (defaultTrust: reject)
```

## Fix

Each page in the list response now includes:
- `keyId`: the publisher's key ID
- `keyUrl`: full URL to the JWK endpoint (`https://zenbin.org/v1/keys/{keyId}/jwk`)

This enables agents to:
1. Get `keyId` from the inbox poll response
2. Fetch the sender's public key via `keyUrl`
3. Verify the sender's signature against the page content

## Related

- Also deployed: provenance headers/meta tags fix for subdomain pages (commit a470f69 on main) — subdomain pages were missing all CAP-* and X-Zenbin-* headers
- CAP Message Skill spec: https://zed.zenbin.org/cap-message-skill