### PR TITLE
fix: add CAP provenance headers to all content types (markdown, image, video)

### DIFF
--- a/src/routes/render.ts
+++ b/src/routes/render.ts
@@ -154,6 +154,9 @@ render.get('/:id', async (c) => {
     return authResponse;
   }
 
+  // Inject CAP Protocol provenance headers for ALL response types (markdown, image, video, HTML)
+  injectProvenanceHttpHeaders(c, page);
+
   const acceptHeader = c.req.header('Accept') || '';
   const wantsJson = acceptHeader.includes('application/json');
   const wantsMarkdown = acceptHeader.includes('text/markdown');
@@ -266,8 +269,7 @@ render.get('/:id', async (c) => {
 
   trackRequestView(c, id);
 
-  injectProvenanceHttpHeaders(c, page);
-
+  // CAP Protocol provenance meta tags (HTTP headers already injected after auth check)
   let html = page.html;
   html = injectProvenanceMeta(html, page);
   html = shouldInjectPostHog(html) ? injectPostHog(html) : html;

--- a/src/routes/subdomainRender.ts
+++ b/src/routes/subdomainRender.ts
@@ -433,6 +433,8 @@ subdomainRender.get('/*', async (c) => {
     return authResponse;
   }
   
+  // Inject CAP Protocol provenance headers for ALL response types
+  injectProvenanceHttpHeaders(c, page);
   if (explicitView === 'raw') {
     const ifNoneMatch = c.req.header('If-None-Match');
     if (etagMatches(ifNoneMatch, page.etag)) {
@@ -528,8 +530,7 @@ subdomainRender.get('/*', async (c) => {
   c.header('Cache-Control', 'public, max-age=0, must-revalidate');
   c.header('Content-Type', getDocumentContentType(page));
   
-  // CAP Protocol provenance headers and meta tags
-  injectProvenanceHttpHeaders(c, page);
+  // CAP Protocol provenance meta tags (HTTP headers already injected after auth check)
   let html = page.html;
   html = injectProvenanceMeta(html, page);
   html = shouldInjectPostHog(html) ? injectPostHog(html) : html;
@@ -564,6 +565,8 @@ subdomainRender.get('/*/raw', extractSubdomain, async (c) => {
   const authResponse = await verifyPageAuth(c, page);
   if (authResponse) {
     return authResponse;
+  // Inject CAP Protocol provenance headers for ALL response types
+  injectProvenanceHttpHeaders(c, page);
   }
   
   // Check If-None-Match for caching
@@ -604,6 +607,8 @@ subdomainRender.get('/*/md', extractSubdomain, async (c) => {
   
   // Check authentication
   const authResponse = await verifyPageAuth(c, page);
+  // Inject CAP Protocol provenance headers for ALL response types
+  injectProvenanceHttpHeaders(c, page);
   if (authResponse) {
     return authResponse;
   }
@@ -643,6 +648,8 @@ subdomainRender.get('/*/image', extractSubdomain, async (c) => {
   if (!page) {
     return c.json({ error: 'Page not found' }, 404);
   }
+  // Inject CAP Protocol provenance headers for ALL response types
+  injectProvenanceHttpHeaders(c, page);
 
   const authResponse = await verifyPageAuth(c, page);
   if (authResponse) {
@@ -672,6 +679,8 @@ subdomainRender.get('/*/video', extractSubdomain, async (c) => {
 
   const page = getPage(pageId, subdomain);
   if (!page) {
+  // Inject CAP Protocol provenance headers for ALL response types
+  injectProvenanceHttpHeaders(c, page);
     return c.json({ error: 'Page not found' }, 404);
   }
 
@@ -730,6 +739,8 @@ export async function serveSubdomainPage(c: any, subdomain: string, path: string
     }
     
     // Otherwise, show 404
+  // Inject CAP Protocol provenance headers for ALL response types
+  injectProvenanceHttpHeaders(c, page);
     c.header('Content-Type', 'text/html; charset=utf-8');
     return c.body(getNotFoundPage(subdomain, path), 404);
   }
@@ -803,8 +814,7 @@ export async function serveSubdomainPage(c: any, subdomain: string, path: string
   c.header('ETag', page.etag);
   c.header('Cache-Control', 'public, max-age=0, must-revalidate');
   
-  // CAP Protocol provenance headers and meta tags
-  injectProvenanceHttpHeaders(c, page);
+  // CAP Protocol provenance meta tags (HTTP headers already injected after auth check)
   let html = page.html;
   html = injectProvenanceMeta(html, page);
   html = shouldInjectPostHog(html) ? injectPostHog(html) : html;

--- a/src/routes/subdomainRender.ts
+++ b/src/routes/subdomainRender.ts
@@ -565,9 +565,10 @@ subdomainRender.get('/*/raw', extractSubdomain, async (c) => {
   const authResponse = await verifyPageAuth(c, page);
   if (authResponse) {
     return authResponse;
+  }
+  
   // Inject CAP Protocol provenance headers for ALL response types
   injectProvenanceHttpHeaders(c, page);
-  }
   
   // Check If-None-Match for caching
   const ifNoneMatch = c.req.header('If-None-Match');
@@ -607,11 +608,12 @@ subdomainRender.get('/*/md', extractSubdomain, async (c) => {
   
   // Check authentication
   const authResponse = await verifyPageAuth(c, page);
-  // Inject CAP Protocol provenance headers for ALL response types
-  injectProvenanceHttpHeaders(c, page);
   if (authResponse) {
     return authResponse;
   }
+  
+  // Inject CAP Protocol provenance headers for ALL response types
+  injectProvenanceHttpHeaders(c, page);
   
   if (!page.markdown) {
     return c.json({ error: 'Page has no markdown content' }, 404);
@@ -648,13 +650,14 @@ subdomainRender.get('/*/image', extractSubdomain, async (c) => {
   if (!page) {
     return c.json({ error: 'Page not found' }, 404);
   }
-  // Inject CAP Protocol provenance headers for ALL response types
-  injectProvenanceHttpHeaders(c, page);
 
   const authResponse = await verifyPageAuth(c, page);
   if (authResponse) {
     return authResponse;
   }
+
+  // Inject CAP Protocol provenance headers for ALL response types
+  injectProvenanceHttpHeaders(c, page);
 
   if (!page.image) {
     return c.json({ error: 'Page has no image content' }, 404);
@@ -679,8 +682,6 @@ subdomainRender.get('/*/video', extractSubdomain, async (c) => {
 
   const page = getPage(pageId, subdomain);
   if (!page) {
-  // Inject CAP Protocol provenance headers for ALL response types
-  injectProvenanceHttpHeaders(c, page);
     return c.json({ error: 'Page not found' }, 404);
   }
 
@@ -688,6 +689,9 @@ subdomainRender.get('/*/video', extractSubdomain, async (c) => {
   if (authResponse) {
     return authResponse;
   }
+
+  // Inject CAP Protocol provenance headers for ALL response types
+  injectProvenanceHttpHeaders(c, page);
 
   if (!page.video) {
     return c.json({ error: 'Page has no video content' }, 404);
@@ -739,8 +743,6 @@ export async function serveSubdomainPage(c: any, subdomain: string, path: string
     }
     
     // Otherwise, show 404
-  // Inject CAP Protocol provenance headers for ALL response types
-  injectProvenanceHttpHeaders(c, page);
     c.header('Content-Type', 'text/html; charset=utf-8');
     return c.body(getNotFoundPage(subdomain, path), 404);
   }
@@ -750,6 +752,9 @@ export async function serveSubdomainPage(c: any, subdomain: string, path: string
   if (authResponse) {
     return authResponse;
   }
+
+  // Inject CAP Protocol provenance headers for ALL response types
+  injectProvenanceHttpHeaders(c, page);
 
   if (explicitView === 'raw') {
     const ifNoneMatch = c.req.header('If-None-Match');


### PR DESCRIPTION
## Problem

Provenance HTTP headers (CAP-*, X-Zenbin-*) were only injected on HTML page renders. Markdown-only, image-only, and video-only pages returned **zero provenance headers**.

This broke sender verification for CAP Message Skill agents receiving messages on markdown-only pages — the content was visible but there was no way to verify who signed it.

Sage's test case (`sage-cap-test-case-1779832045`) demonstrated this: a markdown-only standalone page returned no CAP headers at all, even though the JSON metadata endpoint had all the provenance data.

## Fix

Inject `injectProvenanceHttpHeaders()` right after the auth check in both `render.ts` and `subdomainRender.ts`, before any content-type branching. This ensures ALL response types get CAP headers:

- HTML pages: headers + meta tags
- Markdown pages: headers (no meta tags — not HTML)
- Image/video pages: headers
- JSON metadata: already had provenance fields

## Test

Before fix: `curl -sI https://zenbin.org/p/sage-cap-test-case-1779832045` → no CAP headers
After fix: all CAP headers present on markdown, image, and video responses

349 tests passing.