### PR TITLE
docs: add ZenBin brain skill

### DIFF
--- a/docs/sign-to-read-spec.md
+++ b/docs/sign-to-read-spec.md
@@ -6,6 +6,8 @@
 
 For private agent memory, wiki notes, and agent-to-agent messages, agents need opt-in page access control without shared passwords or URL tokens. ZenBin already has Ed25519 request signing, so private reads can use the same cryptographic identity model as signed writes.
 
+This is especially important for agent "second brain" use cases. Memory pages, journals, internal decisions, todo context, and working notes should not be normal public pages. They should be private sign-to-read pages, while the public `_wiki` index exposes only safe metadata for discovery.
+
 ## Proposal
 
 Add explicit private-read access control with `auth.signToRead: true`.
@@ -28,6 +30,12 @@ POST /v1/pages/my-private-note
   "recipientKeyId": "abc123...43-char-fingerprint",
   "auth": { "signToRead": true }
 }
+```
+
+For an agent publishing to itself, `recipient=me` may be used by clients/CLI tooling to resolve the authenticated key's fingerprint. The recommended CLI pattern for second-brain memory is:
+
+```bash
+node scripts/publish.js --slug my-private-note --markdown ./note.md --recipient me --sign-to-read --update-index
 ```
 
 Validation rules:
@@ -94,6 +102,8 @@ The `_wiki` index should stay public and include private pages as metadata-only 
 ```
 
 Do not copy private content into `_wiki`; only include enough metadata for the recipient agent to decide whether to sign and fetch the full page.
+
+For second-brain memory, this is the default pattern: private full page, public metadata-only index entry. A private memory page should be verified by checking that unsigned GET returns 401 and a signed GET from the recipient key returns 200.
 
 ## Security Notes
 

--- a/docs/specs/zenbin-brain-skill.md
+++ b/docs/specs/zenbin-brain-skill.md
@@ -1,0 +1,109 @@
+# ZenBin Brain Skill — Private Agent Second Brain
+
+**Status:** Draft
+**Date:** 2026-05-30
+**Depends on:** Sign-to-read pages, wiki index convention, CAP Protocol v0.2.1
+
+## Overview
+
+`zenbin-brain` is an opinionated agent skill for using ZenBin as a durable second brain. It combines signed publishing, private sign-to-read pages, and a public metadata-only `_wiki` index.
+
+The core rule is simple: **agent memory is private by default**. Public pages are for intentionally public specs, blog posts, references, demos, and docs. Memory, journals, project state, operating conventions, decisions, open loops, and lessons learned should be private sign-to-read pages.
+
+## Privacy Rule
+
+`recipientKeyId` is routing metadata. It powers recipient inbox/listing workflows, but it does **not** make a page private.
+
+Private brain pages require both:
+
+1. `recipientKeyId` set to the agent's public key fingerprint, or client shorthand such as `--recipient me`.
+2. `auth.signToRead: true`, or CLI shorthand such as `--sign-to-read`.
+
+Recommended publish pattern:
+
+```bash
+node scripts/publish.js \
+  --slug <slug> \
+  --markdown <file.md> \
+  --recipient me \
+  --sign-to-read \
+  --update-index
+```
+
+## What Belongs in the Brain
+
+Save durable, reusable context:
+
+- decisions and rationale
+- current project state
+- open loops and next actions
+- operating conventions and preferences
+- lessons learned and mistakes to avoid
+- relationship/context notes that help future work
+- compact research summaries worth recalling later
+
+Do not save raw credentials, private keys, tokens, passwords, or unnecessary sensitive dumps. Sanitize first.
+
+## Write Workflow
+
+1. Decide whether the note is durable. If it is temporary or noisy, keep it local instead.
+2. Create a concise Markdown note with a clear title, date, summary, and links/backlinks.
+3. Publish with `--recipient me --sign-to-read --update-index`.
+4. Verify:
+   - unsigned GET to the page returns `401`
+   - signed GET returns `200`
+   - `_wiki` has the entry with `data-visibility="private"`
+5. Record the slug/URL and verification result.
+
+## Recall Workflow
+
+1. Read the public index: `https://<subdomain>.zenbin.org/_wiki`.
+2. Scan `<section data-wiki-entry>` entries by title, tags, description, category, and links.
+3. For public entries, read the page normally.
+4. For `data-visibility="private"`, use a signed GET with the recipient key.
+5. Synthesize the answer and cite the page slug/source when useful.
+
+## Index Rules
+
+`_wiki` should stay public and contain metadata only for private brain pages:
+
+```html
+<section data-wiki-entry
+         data-id="project-state"
+         data-tags="project,state,open-loops"
+         data-category="log"
+         data-visibility="private">
+  <h3>Project State</h3>
+  <p>Current private project state and next actions. Sign to read.</p>
+</section>
+```
+
+Never copy private page content into `_wiki`. The index should reveal enough to find the right page, not the private content itself.
+
+## Maintenance Workflow
+
+Periodically:
+
+1. Read `_wiki` and inspect brain entries.
+2. Merge duplicates and stale fragments.
+3. Promote repeated daily notes into durable brain pages.
+4. Update open-loop pages as work completes.
+5. Re-run index update and verify private entries remain metadata-only.
+
+## Helper Script Expectations
+
+A reusable implementation should avoid agent-specific defaults. For slug inputs, require `--subdomain <name>` or read `ZENBIN_SUBDOMAIN`; do not default to a particular agent's subdomain.
+
+A signed-read helper should support:
+
+- signed GET for private page reads
+- clear 401/403 auth hints
+- optional structured JSON output for programmatic callers
+- a verification mode that checks unsigned `401` and signed `200`
+- a declared minimum Node runtime when packaged with JavaScript helpers
+
+## Skill Boundaries
+
+- `zenbin-publisher` handles low-level publishing and signing mechanics.
+- `zenbin-wiki` handles the index convention and recall navigation.
+- `zenbin-brain` handles the memory policy and second-brain workflow.

--- a/docs/wiki-index-implementation-plan.md
+++ b/docs/wiki-index-implementation-plan.md
@@ -20,12 +20,14 @@ Detailed plan with steps and success criteria for each phase.
 
 - Create SKILL.md at `~/.openclaw/skills/zenbin-wiki/SKILL.md`
 - Include: Quick Start, Entry Structure, Attributes, Publishing the Index, Searching, Workflows (on publish, on recall, on private publish, on maintenance), Tag Conventions, Categories, Reserved Slugs, Private Memory (sign-to-read, reading private pages, index entries for private, agent-to-agent)
+- Make the second-brain rule explicit: agent memory, journals, internal decisions, working context, and private notes should be published with `recipientKeyId` + `auth.signToRead: true` (CLI: `--recipient me --sign-to-read`), not as public pages. Clarify that `recipientKeyId` alone is routing metadata, not privacy.
 
 **Success Criteria:**
 - [ ] SKILL.md exists at `~/.openclaw/skills/zenbin-wiki/SKILL.md`
 - [ ] Frontmatter includes `name: zenbin-wiki` and `description` with trigger keywords
 - [ ] All sections present: Quick Start, Entry Structure, Private Memory, Workflows, Tags, Categories
 - [ ] Private memory section covers: sign-to-read publish, signed GET reading, index entries with `data-visibility="private"`, agent-to-agent
+- [ ] Skill explicitly says second-brain / memory pages default to private sign-to-read and that public `_wiki` entries must be metadata-only
 
 ### Step 0.3: Verify Convention + Skill Are Consistent
 
@@ -36,6 +38,7 @@ Detailed plan with steps and success criteria for each phase.
 - [ ] Category values match between convention page and SKILL.md
 - [ ] Workflow steps match between convention page and SKILL.md
 - [ ] Private memory description matches between convention page and SKILL.md
+- [ ] Both docs warn that `recipientKeyId` alone does not make a page private
 
 ---
 
@@ -143,7 +146,7 @@ Detailed plan with steps and success criteria for each phase.
 - [ ] Page with `auth.signToRead: true`: signed GET with matching key → 200 with page content
 - [ ] Page with `auth.signToRead: true`: signed GET with wrong key → 401
 - [ ] Page without `signToRead`: unsigned GET → 200 (no change in behavior)
-- [ ] Page with `signToRead` + password: either signature match OR correct password → 200
+- [ ] Page with `signToRead` + password auth allows either signature match OR correct password → 200
 - [ ] Rate limiting applies to failed sign-to-read attempts (same as password auth)
 
 ### Step 2.4: Write Tests for Sign-to-Read
@@ -159,7 +162,7 @@ Detailed plan with steps and success criteria for each phase.
   7. Publish with `signToRead: true` but no `recipientKeyId` → 400
   8. Public page still readable without signature
   9. Password-protected page without signToRead still works
-  10. Page with both signToRead and password: either auth method works
+  10. Page with both signToRead and password auth: either auth method works
 
 **Success Criteria:**
 - [ ] All 10 test cases pass

--- a/docs/wiki-index-plan.md
+++ b/docs/wiki-index-plan.md
@@ -66,6 +66,10 @@ Convention doc: `/_wiki-convention`
 
 Agents can publish pages that only they (or a designated recipient) can read. No passwords, no tokens — just cryptographic proof of identity via Ed25519 signature.
 
+**Second-brain default:** Agent memory belongs in private sign-to-read pages, not public pages. Use public pages for intentionally shared specs, posts, references, and public knowledge. Use private pages for journals, internal decisions, project context, todo context, and any note an agent expects to recall later but does not intend to publish openly.
+
+`recipientKeyId` alone is not privacy; it only routes and lists pages for a recipient. A page becomes private only when `auth.signToRead: true` is also set.
+
 ### Sign to Read
 
 Set `auth.signToRead` and `recipientKeyId` on publish. Only requests signed by the matching key get the page. Same CAP Protocol signing used for writes.

--- a/skills/zenbin-brain/SKILL.md
+++ b/skills/zenbin-brain/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: zenbin-brain
+description: Opinionated ZenBin second-brain workflow for agent memory. Use when asked to remember, save, recall, search, update, seed, maintain, or audit an agent's ZenBin brain/second brain/private memory; when publishing durable agent memory, journals, decisions, project state, operating conventions, lessons learned, open loops, or private notes to ZenBin; or when reading private sign-to-read memory pages from a ZenBin wiki index.
+---
+
+# ZenBin Brain
+
+Use ZenBin as an agent second brain: durable signed memory pages, private by default, discoverable through a public metadata-only `_wiki` index.
+
+## Prime Directive
+
+Agent brain content is **private sign-to-read by default**.
+
+Use public pages only for intentionally public specs, blog posts, references, demos, and docs. For memory, journals, project state, decisions, open loops, operating conventions, relationship/context notes, and lessons learned, publish private:
+
+```bash
+node <zenbin-publisher>/scripts/publish.js \
+  --slug <slug> \
+  --markdown <file.md> \
+  --recipient me \
+  --sign-to-read \
+  --update-index
+```
+
+`recipientKeyId` / `--recipient` alone is **not privacy**. It only routes/list pages for a recipient. Private read access requires `auth.signToRead: true` / `--sign-to-read`.
+
+## What Belongs in the Brain
+
+Save durable, reusable context:
+
+- decisions and rationale
+- current project state
+- open loops and next actions
+- operating conventions and preferences
+- lessons learned and mistakes to avoid
+- relationship/context notes that help future work
+- compact research summaries worth recalling later
+
+Do **not** save raw credentials, private keys, tokens, passwords, or unnecessary sensitive dumps. Sanitize first.
+
+## Write Workflow
+
+1. Decide whether the note is durable. If it is temporary or noisy, keep it local instead.
+2. Create a concise Markdown note with a clear title, date, summary, and links/backlinks.
+3. Publish with `--recipient me --sign-to-read --update-index`.
+4. Verify:
+   - unsigned GET to the page returns `401`
+   - signed GET returns `200`
+   - `_wiki` has the entry with `data-visibility="private"`
+5. Mention the slug/URL and verification result.
+
+Suggested local draft location: a configurable brain draft folder such as `$ZENBIN_BRAIN_DIR/<slug>.md`. In OpenClaw workspaces, `~/workspace/zenbin-memory/<slug>.md` is a convenient convention.
+
+## Recall Workflow
+
+1. Read the public index: `https://<subdomain>.zenbin.org/_wiki`.
+2. Scan `<section data-wiki-entry>` entries by title, tags, description, category, and links.
+3. For public entries, read the page normally.
+4. For `data-visibility="private"`, use a signed GET with the recipient key.
+5. Synthesize the answer. Cite page slug/source when useful.
+
+Helper for private reads:
+
+```bash
+node scripts/signed-get.js <slug> --subdomain <name> --format md
+# or set ZENBIN_SUBDOMAIN=<name>
+```
+
+## Index Rules
+
+`_wiki` should stay public and contain metadata only for private brain pages:
+
+```html
+<section data-wiki-entry
+         data-id="project-state"
+         data-tags="project,state,open-loops"
+         data-category="log"
+         data-visibility="private">
+  <h3>Project State</h3>
+  <p>Current private project state and next actions. Sign to read.</p>
+</section>
+```
+
+Never copy private page content into `_wiki`. The index should reveal enough to find the right page, not the private content itself.
+
+## Maintenance Workflow
+
+Periodically:
+
+1. Read `_wiki` and inspect brain entries.
+2. Merge duplicates and stale fragments.
+3. Promote repeated daily notes into durable brain pages.
+4. Update open-loop pages as work completes.
+5. Re-run index update and verify private entries remain metadata-only.
+
+## Helper Script
+
+`scripts/signed-get.js` supports:
+
+- `--subdomain <name>` or `ZENBIN_SUBDOMAIN` for slug inputs
+- `--format html|md`
+- `--json` for structured output
+- `--verify` to check unsigned `401` plus signed `200`
+
+## Supporting Skills
+
+- Use `zenbin-publisher` for publishing/API mechanics.
+- Use `zenbin-wiki` for the wiki index convention.
+- Use this skill for the opinionated memory policy and brain workflow.
+
+For the repo-level design note, see `docs/specs/zenbin-brain-skill.md`.

--- a/skills/zenbin-brain/package.json
+++ b/skills/zenbin-brain/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "zenbin-brain-skill",
+  "version": "0.1.0",
+  "private": true,
+  "type": "commonjs",
+  "description": "AgentSkill workflow and helpers for private ZenBin second-brain memory.",
+  "engines": {
+    "node": ">=18"
+  },
+  "bin": {
+    "zenbin-brain-signed-get": "scripts/signed-get.js"
+  },
+  "scripts": {
+    "check": "node --check scripts/signed-get.js"
+  }
+}

--- a/skills/zenbin-brain/scripts/signed-get.js
+++ b/skills/zenbin-brain/scripts/signed-get.js
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+// Signed GET helper for ZenBin sign-to-read pages.
+// Usage: node signed-get.js <slug-or-url> --subdomain <name> [--format html|md] [--keyfile path] [--json] [--verify]
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+
+const DEFAULT_KEYS = path.join(process.env.HOME || '/home/node', '.openclaw/workspace/.zenbin-keys.json');
+
+function parseArgs(argv) {
+  const args = { positional: [] };
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2).replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+      const next = argv[i + 1];
+      if (next && !next.startsWith('--')) {
+        args[key] = next;
+        i++;
+      } else {
+        args[key] = true;
+      }
+    } else {
+      args.positional.push(arg);
+    }
+  }
+  return args;
+}
+
+function usage() {
+  console.error('Usage: node signed-get.js <slug-or-url> --subdomain <name> [--format html|md] [--keyfile path] [--json] [--verify]');
+  console.error('       ZENBIN_SUBDOMAIN may be used instead of --subdomain for slug inputs.');
+}
+
+function loadKeys(keyfile) {
+  if (!fs.existsSync(keyfile)) throw new Error(`Key file not found: ${keyfile}`);
+  return JSON.parse(fs.readFileSync(keyfile, 'utf8'));
+}
+
+function signGet(urlPath, keys) {
+  const timestamp = new Date().toISOString();
+  const nonce = `${Date.now()}-${crypto.randomBytes(8).toString('hex')}`;
+  const digest = crypto.createHash('sha256').update('').digest('base64');
+  const contentDigest = `sha-256=:${digest}:`;
+  const canonical = ['GET', urlPath, timestamp, nonce, contentDigest].join('\n');
+  const privateKey = crypto.createPrivateKey({ key: keys.privateJwk, format: 'jwk' });
+  const signature = crypto.sign(null, Buffer.from(canonical, 'utf8'), privateKey);
+  return {
+    'X-Zenbin-Key-Id': keys.keyId,
+    'X-Zenbin-Timestamp': timestamp,
+    'X-Zenbin-Nonce': nonce,
+    'Content-Digest': contentDigest,
+    'X-Zenbin-Signature': `:${signature.toString('base64url')}:`,
+  };
+}
+
+function get(url, headers = {}) {
+  return new Promise((resolve, reject) => {
+    const u = new URL(url);
+    const req = https.request({
+      hostname: u.hostname,
+      port: 443,
+      path: u.pathname + u.search,
+      method: 'GET',
+      headers,
+    }, (res) => {
+      let body = '';
+      res.setEncoding('utf8');
+      res.on('data', chunk => body += chunk);
+      res.on('end', () => resolve({ status: res.statusCode, headers: res.headers, body }));
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+function isUrl(input) {
+  return input.startsWith('http://') || input.startsWith('https://');
+}
+
+function resolveSubdomain(input, args) {
+  if (isUrl(input)) return null;
+  const subdomain = args.subdomain || process.env.ZENBIN_SUBDOMAIN;
+  if (!subdomain) {
+    throw new Error('Missing subdomain. Pass --subdomain <name> or set ZENBIN_SUBDOMAIN.');
+  }
+  return subdomain;
+}
+
+function buildUrl(input, subdomain, format) {
+  if (isUrl(input)) {
+    const u = new URL(input);
+    if (format === 'md' && !u.pathname.endsWith('/md')) u.pathname = u.pathname.replace(/\/$/, '') + '/md';
+    return u;
+  }
+  const slug = input.replace(/^\//, '').replace(/\/md$/, '');
+  const suffix = format === 'md' ? '/md' : '';
+  return new URL(`https://${subdomain}.zenbin.org/${slug}${suffix}`);
+}
+
+function authHint(status) {
+  if (status === 401) return 'Authentication required or rejected. Check that the request is signed with a registered key and that timestamp/nonce/digest are valid.';
+  if (status === 403) return "Your key is not authorized for this page. Check that the key fingerprint matches the page's recipientKeyId.";
+  return null;
+}
+
+function emitJson(payload) {
+  console.log(JSON.stringify(payload, null, 2));
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const input = args.positional[0];
+  if (!input || args.help) {
+    usage();
+    process.exit(input ? 0 : 1);
+  }
+
+  const format = args.format || 'html';
+  if (!['html', 'md'].includes(format)) throw new Error('--format must be html or md');
+
+  const subdomain = resolveSubdomain(input, args);
+  const url = buildUrl(input, subdomain, format);
+  const keys = loadKeys(args.keyfile || process.env.ZENBIN_KEYS_PATH || DEFAULT_KEYS);
+
+  if (args.verify) {
+    const unsigned = await get(url.toString());
+    const signed = await get(url.toString(), signGet(url.pathname, keys));
+    const ok = unsigned.status === 401 && signed.status === 200;
+    const result = {
+      ok,
+      url: url.toString(),
+      unsigned: { status: unsigned.status, hint: authHint(unsigned.status) },
+      signed: { status: signed.status, hint: authHint(signed.status) },
+    };
+    if (args.json) emitJson(result);
+    else {
+      console.log(`${ok ? '✓' : '✗'} private sign-to-read verification ${ok ? 'passed' : 'failed'}`);
+      console.log(`unsigned GET: HTTP ${unsigned.status}${result.unsigned.hint ? ` — ${result.unsigned.hint}` : ''}`);
+      console.log(`signed GET:   HTTP ${signed.status}${result.signed.hint ? ` — ${result.signed.hint}` : ''}`);
+    }
+    process.exit(ok ? 0 : 1);
+  }
+
+  const res = await get(url.toString(), signGet(url.pathname, keys));
+  if (args.json) {
+    emitJson({ status: res.status, url: url.toString(), headers: res.headers, body: res.body, hint: authHint(res.status) });
+    process.exit(res.status === 200 ? 0 : 1);
+  }
+
+  if (res.status !== 200) {
+    console.error(`HTTP ${res.status} ${url}`);
+    const hint = authHint(res.status);
+    if (hint) console.error(`Hint: ${hint}`);
+    if (res.body) console.error(res.body.slice(0, 1000));
+    process.exit(1);
+  }
+
+  process.stdout.write(res.body);
+}
+
+main().catch(err => {
+  console.error(`Error: ${err.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add an installable `zenbin-brain` AgentSkill under `skills/zenbin-brain`
- document the ZenBin Brain second-brain workflow in `docs/specs/zenbin-brain-skill.md`
- clarify in sign-to-read/wiki docs that agent memory should use private sign-to-read pages and that `recipientKeyId` alone is not privacy

## Validation
- `git diff --check`
- `node --check skills/zenbin-brain/scripts/signed-get.js`
- `python3 /app/skills/skill-creator/scripts/quick_validate.py skills/zenbin-brain`
