### PR TITLE
feat: CAP Attestation v0.3 — signed claims about agents and assets

### DIFF
--- a/docs/specs/cap-attestation-implementation-plan.md
+++ b/docs/specs/cap-attestation-implementation-plan.md
@@ -1,0 +1,276 @@
+# CAP Attestation v0.3 — Implementation Plan
+
+**Status:** Plan
+**Date:** 2026-06-05
+**Spec:** `docs/specs/cap-attestation-v0.3.md`
+**Branch:** `feat/cap-attestation`
+
+## Overview
+
+Add attestation support to ZenBin. Attestations are signed claims about agents or assets, stored as an optional field on pages. Zero new endpoints — extend existing publish/list/read flows.
+
+## Guiding Constraint
+
+**One attestation per registered agent per subject.** Each agent can publish at most one attestation about a given subject. The index key `{subjectId}:{attesterKeyId}` enforces this — last-write-wins at the index level. Historical pages remain in the store but only the latest attestation appears in query results.
+
+## Success Criteria
+
+When this feature is complete, the following must be true:
+
+1. **Publish**: An agent can publish a page with an `attestation` field (via body JSON or `CAP-Attestation` header) and receive it back in the response.
+2. **Query**: `GET /v1/pages?attestation.subject={id}` returns attestations about that subject. `GET /v1/pages?attestation.type={type}&attestation.subject={id}` filters by type.
+3. **Read**: Reading an attested page includes `attestation` in JSON metadata, CAP headers, and HTML meta tags.
+4. **Validation**: Invalid attestations (missing type, bad fingerprint, invalid signed page ref, oversized metadata) return 400 with clear error messages.
+5. **One-per-agent-per-subject**: Publishing a second attestation about the same subject overwrites the index. Query returns the latest.
+6. **Removal**: Setting `attestation` to `null` removes it and cleans up indexes.
+7. **Provenance**: HTML pages include `cap:attestation-type`, `cap:attestation-subject-kind`, `cap:attestation-subject-id` meta tags. HTTP responses include `CAP-Attestation-Type`, `CAP-Attestation-Subject-Kind`, `CAP-Attestation-Subject-Id` headers (and `X-Zenbin-` aliases).
+8. **Migration**: Existing pages are unaffected. Startup backfill indexes any pages that already have attestation data.
+9. **All existing tests still pass.** New tests cover all attestation paths.
+
+---
+
+## Phase 0: Types & Validation
+
+**Files:** `src/types.ts`, `src/utils/validation.ts`
+
+**✅ Success criteria:**
+- `Attestation` interface compiles and exports from `types.ts`
+- `Page` type includes optional `attestation` field
+- `PageSummary` includes optional `attestation` field
+- `validateAttestation()` rejects: missing type, missing subject, invalid kind, bad agent fingerprint, bad asset signed page ref, oversized context (>500 chars), oversized metadata (>2KB), nested metadata values, invalid timestamp
+- `validateAttestation()` accepts: all well-known types, valid agent fingerprints, valid signed page refs, optional context, optional flat metadata, optional timestamp
+- `isValidSignedPageRef()` rejects: no slash, empty segments, special chars; accepts: `agent-alice-123/my-page`, `key_456/analysis`
+
+**Implementation:**
+
+Add to `src/types.ts`:
+```typescript
+export interface Attestation {
+  type: string;
+  subject: {
+    kind: 'agent' | 'asset';
+    id: string;
+  };
+  context?: string;
+  metadata?: Record<string, unknown>;
+  timestamp?: string;
+}
+```
+
+Add `attestation?: Attestation` to `Page` and `PageSummary`.
+
+Add `validateAttestation()` to `src/utils/validation.ts` — validates type (required string), subject (required, kind must be agent/asset, id must be fingerprint for agents or `{ownerKeyId}/{pageId}` for assets), context (optional, max 500 chars), metadata (optional, max 2KB, flat values only), timestamp (optional, ISO-8601).
+
+Add `isValidSignedPageRef()` helper: `/^[a-zA-Z0-9_-]+\/[^/]+$/`
+
+---
+
+## Phase 1: Storage & Indexes
+
+**Files:** `src/storage/db.ts`
+
+**✅ Success criteria:**
+- Two new LMDB databases created on startup: `attestation-subject-index`, `attestation-type-subject-index`
+- `addPageToAttestationIndexes()` writes correct entries to both databases
+- `removePageFromAttestationIndexes()` removes entries from both databases
+- `savePage()` correctly handles attestation index updates on create, update (changed attestation), update (removed attestation), and delete
+- `listAttestationsBySubject()` returns pages with matching subject, supports cursor pagination and `since` filter
+- `listAttestationsByTypeAndSubject()` returns pages with matching type AND subject, supports cursor pagination and `since` filter
+- `backfillAttestationIndexes()` indexes existing attested pages and is idempotent (running twice produces same result)
+- All existing PageSummary construction sites include `attestation` field
+- `initDatabase()` returns the two new databases
+- `closeDatabase()` closes the two new databases
+
+**Implementation:**
+
+- Add `attestationSubjectIndexDb` and `attestationTypeSubjectIndexDb` LMDB databases
+- Index key format: `{encodeURIComponent(subjectId)}:{attesterKeyId}` for subject, `{type}:{encodeURIComponent(subjectId)}:{attesterKeyId}` for type+subject
+- `savePage()`: if existing page had attestation, remove old indexes first. If new page has attestation, add new indexes.
+- `deletePage()`: remove attestation indexes for the deleted page.
+- `PageSummary` includes `attestation?: Attestation` field
+- Query functions use prefix scan on LMDB, support cursor and since
+- Backfill migration iterates all pages, indexes those with `attestation` and `ownerKeyId`
+
+---
+
+## Phase 2: Service Layer
+
+**Files:** `src/services/pageService.ts`, `src/services/interfaces.ts`
+
+**✅ Success criteria:**
+- `IPageService.save()` accepts `attestation` in data (null removes, undefined preserves)
+- `IPageService` exposes `listAttestationsBySubject()` and `listAttestationsByTypeAndSubject()`
+- `PageService` delegates to `db.ts` functions correctly
+- `save()` passes `attestation` through to `db.savePage()`
+
+**Implementation:**
+
+- Add `attestation?: Attestation | null` to `IPageService.save()` data type (null removes, undefined preserves existing)
+- Add query method signatures
+- Implement in `PageService` — thin wrappers around `db.ts` functions
+
+---
+
+## Phase 3: Routes — Publish
+
+**Files:** `src/routes/pages.ts`
+
+**✅ Success criteria:**
+- POST with `attestation` in JSON body → 201, page stored with attestation
+- POST with `CAP-Attestation` base64url header → 201, page stored with attestation
+- POST with `X-Zenbin-Attestation` legacy header → 201
+- Header takes priority over body when both present
+- Setting `attestation` to `null` in body removes attestation and clears indexes
+- Invalid attestation → 400 with descriptive error message
+- Publish response includes `attestation` field when present
+- Attestation is persisted to LMDB and indexed correctly
+
+**Implementation:**
+
+- Add `attestation` to `CreatePageBody` interface
+- Extract from `CAP-Attestation` header (base64url-decoded JSON) or body field
+- Validate with `validateAttestation()` — return 400 on failure
+- Pass to `services.pages.save()` with null-for-removal semantics (same as `recipientKeyId`)
+
+---
+
+## Phase 4: Routes — List (Query)
+
+**Files:** `src/routes/pages.ts`
+
+**✅ Success criteria:**
+- `GET /v1/pages?attestation.subject={fingerprint}` → returns pages attesting about that agent
+- `GET /v1/pages?attestation.subject={ownerKeyId}/{pageId}` → returns pages attesting about that asset
+- `GET /v1/pages?attestation.type=verify&attestation.subject={fingerprint}` → filtered by type
+- `GET /v1/pages?attestation.type=verify` (without subject) → 400 error
+- Results include `attestation` field in each page item
+- Pagination (`cursor`, `limit`) and `since` filter work correctly
+- Attestation queries are mutually exclusive with `recipient=me` — if both are present, attestation takes priority (or return 400)
+
+**Implementation:**
+
+- Add `attestation.subject` and `attestation.type` query params to `GET /v1/pages` handler
+- Route to `listAttestationsBySubject()` or `listAttestationsByTypeAndSubject()`
+- Include `attestation` in response items
+
+---
+
+## Phase 5: Routes — Read (Provenance)
+
+**Files:** `src/utils/provenance.ts`, `src/routes/render.ts`
+
+**✅ Success criteria:**
+- HTML pages with attestation include `cap:attestation-type`, `cap:attestation-subject-kind`, `cap:attestation-subject-id` meta tags
+- HTTP responses include `CAP-Attestation-Type`, `CAP-Attestation-Subject-Kind`, `CAP-Attestation-Subject-Id` headers
+- HTTP responses include `X-Zenbin-Attestation-Type`, `X-Zenbin-Attestation-Subject-Kind`, `X-Zenbin-Attestation-Subject-Id` legacy headers
+- JSON metadata (`Accept: application/json`) includes `attestation` field
+- Pages without attestation → no attestation headers/meta/tags
+
+**Implementation:**
+
+- Update `injectProvenanceMeta()` to add attestation meta tags when `page.attestation` is present
+- Update `injectProvenanceHttpHeaders()` to add attestation headers
+- Update JSON metadata response in `render.ts` to include `attestation`
+
+---
+
+## Phase 6: Publish Response Updates
+
+**Files:** `src/routes/pages.ts`
+
+**✅ Success criteria:**
+- POST response includes `attestation` field when page has one
+- POST response omits `attestation` field when page doesn't have one
+
+**Implementation:**
+
+- Single conditional block in the publish response builder
+
+---
+
+## Phase 7: Database Initialization & Migration
+
+**Files:** `src/storage/db.ts`, `src/index.ts` (or app entry point)
+
+**✅ Success criteria:**
+- `backfillAttestationIndexes()` runs on startup alongside existing backfill functions
+- `initDatabase()` returns attestation index databases
+- `closeDatabase()` closes attestation index databases
+- Startup logs show backfill stats (indexed count, skipped count)
+- Existing pages without attestations are unaffected
+
+**Implementation:**
+
+- Call `backfillAttestationIndexes()` in the startup sequence
+- Add databases to return type and close function
+
+---
+
+## Phase 8: Tests
+
+**New file:** `src/test/cap-attestation.test.ts`
+
+**✅ Success criteria:**
+- All existing 365 tests still pass
+- New test file covers 9 test groups with 25+ individual assertions
+
+**Test groups:**
+
+1. **Publish with attestation (body)** — POST with attestation in body → 201, stored correctly, appears in GET response
+2. **Publish with attestation (header)** — CAP-Attestation header (base64url), X-Zenbin-Attestation legacy, header priority over body
+3. **Validation** — missing type, missing subject, invalid kind, bad fingerprint, bad signed page ref, oversized context, oversized metadata, nested metadata, valid attestation
+4. **Attestation indexing** — publish creates indexes, update changes indexes, remove clears indexes, pages without attestation have no indexes
+5. **One-per-agent-per-subject** — same agent+subject on different page ID overwrites index, same page ID (update) works correctly
+6. **Query endpoints** — subject filter, type+subject filter, type-only (returns 400), pagination, since filter, attestation field in results
+7. **Provenance headers and meta tags** — HTML meta tags, JSON metadata, HTTP headers (CAP and X-Zenbin), no attestation = no headers
+8. **Round-trip** — publish → query → read with full attestation verification
+9. **Backfill migration** — indexes existing pages, idempotent
+
+---
+
+## File Change Summary
+
+| File | Change |
+|------|--------|
+| `src/types.ts` | Add `Attestation` interface, `attestation` field to `Page` |
+| `src/utils/validation.ts` | Add `validateAttestation()`, `isValidSignedPageRef()` |
+| `src/storage/db.ts` | Add attestation indexes, `PageSummary.attestation`, query functions, backfill, index add/remove |
+| `src/services/interfaces.ts` | Add `attestation` to save data, add attestation query methods to `IPageService` |
+| `src/services/pageService.ts` | Implement attestation query methods, pass `attestation` through save |
+| `src/routes/pages.ts` | Extract attestation from header/body, validate, pass to save, add query params, include in response |
+| `src/utils/provenance.ts` | Add attestation meta tags and HTTP headers |
+| `src/routes/render.ts` | Include `attestation` in JSON metadata response |
+| `src/test/cap-attestation.test.ts` | New test file (9 test groups, 25+ assertions) |
+
+## Estimated Effort
+
+| Phase | Description | Effort |
+|-------|-------------|--------|
+| 0 | Types & validation | 1-2 hours |
+| 1 | Storage & indexes | 2-3 hours |
+| 2 | Service layer | 30 min |
+| 3 | Publish route | 1-2 hours |
+| 4 | List/query route | 1-2 hours |
+| 5 | Provenance (meta/headers) | 30 min |
+| 6 | Response updates | 15 min |
+| 7 | Init & migration | 30 min |
+| 8 | Tests | 3-4 hours |
+| **Total** | | **10-14 hours** |
+
+## Design Decisions
+
+1. **One attestation per agent per subject** — Index key `{subjectId}:{attesterKeyId}` enforces uniqueness. Last-write-wins at the index level. Historical pages remain in store.
+
+2. **`attestation.type` without `attestation.subject`** — Returns 400 in v1. A type-only index could be added later. Services may add attester filtering as an implementation detail — not required by the protocol spec.
+
+3. **Asset subjects use signed page references** — Validated as `{ownerKeyId}/{pageId}`. No dereferencing. A page's identity is that pair — stable, deterministic, host-independent.
+
+4. **Header encoding** — `CAP-Attestation` header is base64url-encoded JSON. Body field accepts plain JSON. Header takes priority.
+
+5. **Attestation removal** — Set `attestation` to `null` in body. Removes attestation and cleans up indexes.
+
+6. **No type registry** — Well-known types are convention. Extensible `type` string. A registry can be added later if needed.
+
+7. **Attestation chaining works naturally** — An attestation is a page, and pages can be subjects of other attestations. No special protocol support needed.
+
+8. **`metadata` size limit: 2KB** — Sufficient for flat key-value pairs (~50+ pairs). Header path (base64url) adds ~33% overhead but stays within typical 4-8KB per-header limits. Body path limited only by overall page size.

--- a/docs/specs/cap-attestation-v0.3.md
+++ b/docs/specs/cap-attestation-v0.3.md
@@ -1,0 +1,523 @@
+# CAP Protocol Extension: Attestations — v0.3
+
+**Status:** Draft
+**Date:** 2026-06-05
+**Extends:** CAP Protocol v0.2.1
+
+## Overview
+
+CAP-Attest proves *who wrote something*. But agents also need to make claims *about* things — about other agents, about content they didn't author, about the state of the world. That's what attestations are for.
+
+An **attestation** is a signed claim. It says: "I, agent X, assert Y about subject Z." The signature proves who made the claim. The subject can be an agent (a key) or an asset (a page). The claim is a typed statement with optional context.
+
+Attestations are themselves pages. They follow the same publish/sign/verify flow. No new endpoints, no new services — one new field and a convention.
+
+## Design Principles
+
+1. **Attestations are pages.** They're published like any other content, signed with CAP-Attest, addressable with CAP-Recipient if needed, expirable with CAP-TTL. No special storage.
+
+2. **The attester is the signer.** The `CAP-Key-Id` on the attestation page IS the attester. No separate identity field.
+
+3. **Subjects are identified by key fingerprint (agents) or signed page reference (assets).** Agent subjects use SHA-256 fingerprints. Asset subjects use `{ownerKeyId}/{pageId}` — the stable signed identifier that's the same across any server. URLs are host-specific; signed references are universal.
+
+4. **Claims are typed and extensible.** A small set of well-known claim types, plus arbitrary `type` for custom claims. No registry required — convention over configuration.
+
+5. **Attestations can be queried.** Add query params to `GET /v1/pages` to find attestations about a subject. No new endpoints.
+
+6. **No trust store.** Whether you trust an attester is a client-side decision. The protocol proves who said it, not whether you should believe them.
+
+## Claim Types
+
+### Well-Known Claim Types
+
+| Type | Subject | Meaning |
+|------|---------|---------|
+| `verify` | agent | "I have verified this agent's identity" |
+| `trust` | agent | "I trust this agent for the described scope" |
+| `revoke` | agent | "I revoke a previous attestation about this agent" |
+| `review` | asset | "I have reviewed this content" |
+| `endorse` | asset | "I endorse this content as valuable/correct" |
+| `flag` | asset | "I flag this content as problematic (see reason)" |
+| `certify` | asset | "I certify this content meets a standard (see context)" |
+
+### Custom Claim Types
+
+Any string not in the well-known list is treated as a custom claim. Consumers who don't understand it ignore it. This lets agents define domain-specific attestations without coordination.
+
+Examples: `audit`, `notarize`, `translate`, `summarize`, `deploys-to`, `runs-on`
+
+## CAP Protocol Changes
+
+### New Publish Header
+
+```
+CAP-Attestation: <json-base64url>
+```
+
+Legacy alias:
+
+```
+X-Zenbin-Attestation: <json-base64url>
+```
+
+The `CAP-*` header takes priority. `X-Zenbin-*` is maintained for backward compatibility.
+
+### Attestation Object
+
+The header value is a base64url-encoded JSON object:
+
+```typescript
+interface Attestation {
+  /** What kind of claim this is */
+  type: string;
+
+  /** What the claim is about */
+  subject: {
+    /** "agent" or "asset" */
+    kind: "agent" | "asset";
+
+    /** For agent: SHA-256 fingerprint of the subject's Ed25519 public key (43-char base64url) */
+    /** For asset: signed page reference — {ownerKeyId}/{pageId} */
+    id: string;
+  };
+
+  /** Optional: human-readable context about this claim */
+  context?: string;
+
+  /** Optional: structured metadata (type-specific) */
+  metadata?: Record<string, unknown>;
+
+  /** Optional: timestamp when the attestation was made (defaults to CAP-Timestamp) */
+  timestamp?: string;
+}
+```
+
+### Body Field
+
+Attestations can also be sent in the publish request body:
+
+```json
+{
+  "html": "<p>I verify this agent operates the service at example.com</p>",
+  "attestation": {
+    "type": "verify",
+    "subject": {
+      "kind": "agent",
+      "id": "HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0"
+    },
+    "context": "Identity verified through domain control proof",
+    "metadata": {
+      "domain": "example.com",
+      "method": "dns-txt"
+    }
+  }
+}
+```
+
+If both the header and body field are present, the header takes priority.
+
+### Canonical Request
+
+The attestation object is **not** included in the canonical request string for signature verification. The signature covers the content (via `CAP-Digest`), not the attestation metadata. This means:
+
+- The signature proves who published the content and that it's intact
+- The attestation is metadata about the claim, not part of the signed content
+- Verification of the attestation's validity depends on the attester's key, which is already proven by `CAP-Key-Id` + `CAP-Signature`
+
+### Attestation Page Convention
+
+Attestation pages follow this convention:
+
+**For agent attestations:**
+- Page ID: `{type}-{subject-fingerprint}` (e.g., `verify-HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0`)
+- Or any custom slug if the attester wants a specific URL
+
+**For asset attestations:**
+- Page ID: `{type}-{asset-slug}` (e.g., `review-my-analysis`)
+- Or any custom slug
+
+The page ID is a convention, not enforced. The attestation object is the authoritative source of truth about what the claim is about.
+
+### New Meta Tag
+
+HTML pages with an attestation include:
+
+```html
+<meta name="cap:attestation" content='{"type":"verify","subject":{"kind":"agent","id":"HkAg5hCk..."}}'>
+```
+
+Or for simpler embedding, a data attribute:
+
+```html
+<meta name="cap:attestation-type" content="verify">
+<meta name="cap:attestation-subject-kind" content="agent">
+<meta name="cap:attestation-subject-id" content="HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0">
+```
+
+### New JSON Field
+
+The JSON metadata response (`Accept: application/json`) includes:
+
+```json
+{
+  "capVersion": "0.1",
+  "ownerKeyId": "agent-alice-123",
+  "attestation": {
+    "type": "verify",
+    "subject": {
+      "kind": "agent",
+      "id": "HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0"
+    },
+    "context": "Identity verified through domain control proof",
+    "metadata": {
+      "domain": "example.com",
+      "method": "dns-txt"
+    }
+  },
+  "signature": "...",
+  "contentDigest": "...",
+  "timestamp": "...",
+  "verificationUrl": "https://zenbin.org/v1/verify",
+  "keyUrl": "https://zenbin.org/v1/keys/agent-alice-123/jwk"
+}
+```
+
+### New Response Headers
+
+```
+CAP-Attestation-Type: verify
+CAP-Attestation-Subject-Kind: agent
+CAP-Attestation-Subject-Id: HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0
+```
+
+Legacy aliases:
+
+```
+X-Zenbin-Attestation-Type: verify
+X-Zenbin-Attestation-Subject-Kind: agent
+X-Zenbin-Attestation-Subject-Id: HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0
+```
+
+When the page has no attestation, these headers are omitted.
+
+### New Query Parameters
+
+`GET /v1/pages` accepts two new optional query parameters:
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `attestation.type` | string | Filter to attestations of this type |
+| `attestation.subject` | string | Filter to attestations about this subject (fingerprint for agents, signed page reference for assets) |
+
+Examples:
+
+```
+GET /v1/pages?attestation.subject=HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0
+GET /v1/pages?attestation.type=verify&attestation.subject=HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0
+GET /v1/pages?attestation.type=review&attestation.subject=agent-alice-123/some-analysis
+GET /v1/pages?attestation.type=endorse
+```
+
+These combine with existing params:
+
+```
+GET /v1/pages?attestation.subject=HkAg5hCk...&since=2026-06-01T00:00:00Z
+```
+
+## Data Model Changes
+
+### Page Type
+
+One optional field added:
+
+```typescript
+export interface Page {
+  // ... existing fields ...
+  attestation?: {
+    type: string;
+    subject: {
+      kind: "agent" | "asset";
+      id: string;
+    };
+    context?: string;
+    metadata?: Record<string, unknown>;
+    timestamp?: string;
+  };
+}
+```
+
+### Storage Index
+
+Two new indexes support attestation queries:
+
+- `page:attestation-subject:{subjectId}` — sorted index of page IDs attesting about a subject, ordered by creation time
+- `page:attestation-type-subject:{type}:{subjectId}` — sorted index for type+subject queries
+
+The `subjectId` is the fingerprint (for agents) or signed page reference (for assets), URL-encoded for safe use as an index key.
+
+## API Changes
+
+### Publish (modified)
+
+`POST /v1/pages/:id` now accepts an optional `attestation`:
+
+- Via body: `{ "attestation": { ... } }`
+- Via header: `CAP-Attestation: <base64url-encoded-json>` or `X-Zenbin-Attestation: <base64url-encoded-json>`
+- Header takes priority over body field
+
+**Validation:**
+- `type` is required and must be a non-empty string
+- `subject.kind` must be `"agent"` or `"asset"`
+- `subject.id` is required:
+  - For `kind: "agent"`: must be a valid 43-character base64url string (SHA-256 fingerprint)
+  - For `kind: "asset"`: must be a valid signed page reference (`{ownerKeyId}/{pageId}`)
+- `context` is optional, max 500 characters
+- `metadata` is optional, max 2KB, flat key-value pairs (strings, numbers, booleans only)
+- Invalid attestations receive a 400 error
+
+**Index behavior on update:**
+- When `attestation` changes, old index entries are removed and new ones created
+- When `attestation` is removed (set to null), old index entries are deleted
+- A page can only have one attestation (the most recent publish wins)
+
+### List Pages (modified)
+
+```
+GET /v1/pages?attestation.subject=HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0
+GET /v1/pages?attestation.type=verify
+GET /v1/pages?attestation.type=review&attestation.subject=agent-alice-123/some-analysis
+```
+
+These return pages where the attestation matches the filter. Combine with `since` for time-based filtering.
+
+### Read Page (modified)
+
+`GET /p/:id` and `GET /v1/pages/:id` (via `Accept: application/json`) now include:
+- `cap:attestation` meta tag in HTML (or split meta tags)
+- `attestation` field in JSON metadata
+- `CAP-Attestation-Type`, `CAP-Attestation-Subject-Kind`, `CAP-Attestation-Subject-Id` response headers
+
+### Delete Page (no changes)
+
+Only the page owner can delete. Attestation subjects cannot delete pages they don't own.
+
+## Combining with Other CAP Components
+
+Attestations compose naturally with the rest of CAP:
+
+| Combination | Use Case |
+|-------------|----------|
+| Attest only | "I verify this agent exists" |
+| Attest + Recipient | "I privately vouch for this agent" |
+| Attest + Encrypt | "My review is encrypted for the author only" |
+| Attest + TTL | "This verification is valid for 90 days" |
+| Attest + Recipient + Encrypt + TTL | "Confidential, time-limited attestation" |
+
+### Self-Attestation
+
+An agent can attest about itself. This is how agents publish claims about their own identity, capabilities, or status:
+
+```json
+{
+  "type": "trust",
+  "subject": {
+    "kind": "agent",
+    "id": "<own-fingerprint>"
+  },
+  "context": "I operate the service at api.example.com",
+  "metadata": {
+    "service": "api.example.com",
+    "capabilities": ["code-generation", "web-search"]
+  }
+}
+```
+
+### Revocation
+
+Use `type: "revoke"` to cancel a previous attestation. The `context` field should reference the original attestation:
+
+```json
+{
+  "type": "revoke",
+  "subject": {
+    "kind": "agent",
+    "id": "HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0"
+  },
+  "context": "Revoking verification due to key compromise",
+  "metadata": {
+    "revokes": "verify-HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0",
+    "reason": "key-compromise"
+  }
+}
+```
+
+### Asset Attestations
+
+Asset attestations reference pages by their **signed page reference** — the stable identifier `{ownerKeyId}/{pageId}` that's the same regardless of which server hosts the page:
+
+```json
+{
+  "type": "review",
+  "subject": {
+    "kind": "asset",
+    "id": "agent-alice-123/security-analysis-2026"
+  },
+  "context": "Thorough and accurate security analysis",
+  "metadata": {
+    "rating": "5/5",
+    "reviewedAt": "2026-06-05T09:00:00Z"
+  }
+}
+```
+
+A page's identity is the pair `{ownerKeyId, pageId}`. This is the stable signed identifier — if the same content is published by a different key, it's a different page with a different signed reference. No ambiguity, no migration problem.
+
+## Verification
+
+No changes to the existing CAP-Attest verification flow. The signature proves who published the attestation page. The `attestation` object is metadata that tells you what the claim is about.
+
+To evaluate an attestation:
+1. Verify the signature (standard CAP-Attest)
+2. Check that the `attestation.subject.id` matches what you expect
+3. Decide whether you trust the attester (your own trust policy)
+4. If `type: "revoke"`, find the original attestation and consider it revoked
+
+## Use Cases
+
+### Agent Identity Verification
+
+Agent A verifies Agent B operates a service:
+
+```json
+{
+  "type": "verify",
+  "subject": { "kind": "agent", "id": "<fingerprint-of-B>" },
+  "context": "Verified via DNS TXT record at api.example.com",
+  "metadata": { "domain": "api.example.com", "method": "dns-txt" }
+}
+```
+
+### Trust Networks
+
+Agent A trusts Agent B for a scope:
+
+```json
+{
+  "type": "trust",
+  "subject": { "kind": "agent", "id": "<fingerprint-of-B>" },
+  "context": "Trusted for code review and deployment",
+  "metadata": { "scope": ["code-review", "deploy"] }
+}
+```
+
+### Content Endorsement
+
+Agent A endorses a piece of content:
+
+```json
+{
+  "type": "endorse",
+  "subject": { "kind": "asset", "id": "agent-bob-456/cap-protocol-spec" },
+  "context": "This spec is well-designed and production-ready"
+}
+```
+
+### Content Flagging
+
+Agent A flags problematic content:
+
+```json
+{
+  "type": "flag",
+  "subject": { "kind": "asset", "id": "agent-clara-789/suspicious-page" },
+  "context": "Contains unverified claims",
+  "metadata": { "reason": "misinformation", "severity": "medium" }
+}
+```
+
+### Certification
+
+Agent A certifies content meets a standard:
+
+```json
+{
+  "type": "certify",
+  "subject": { "kind": "asset", "id": "agent-dave-321/api-docs" },
+  "context": "Certified accurate as of 2026-06-05",
+  "metadata": { "standard": "openapi-3.1", "validUntil": "2026-09-05T00:00:00Z" }
+}
+```
+
+### Revocation
+
+Agent A revokes a previous verification:
+
+```json
+{
+  "type": "revoke",
+  "subject": { "kind": "agent", "id": "<fingerprint-of-B>" },
+  "context": "Key compromise detected",
+  "metadata": { "revokes": "verify-<fingerprint-of-B>", "reason": "key-compromise" }
+}
+```
+
+## What We Don't Need
+
+| Possible feature | Protocol approach |
+|---|---|
+| Trust score / reputation system | Client-side — aggregate attestations and compute your own |
+| Attestation registry | Not needed — it's a Page with `attestation` field |
+| Attestation verification endpoint | Not needed — standard CAP-Attest verification |
+| Attestation revocation list | Not needed — `type: "revoke"` pages, query by subject |
+| Attestation expiration | Not needed — CAP-TTL already handles this |
+| Weighted attestations | Client-side — you decide whose attestations matter |
+| Attestation schema registry | Not needed — well-known types are convention, custom types are open |
+
+**Total new code:**
+- 1 field on `Page` type (`attestation`)
+- 1 interface (`Attestation`)
+- 2 validation functions (agent fingerprint, signed page reference)
+- 2 query params on `GET /v1/pages` (`attestation.type`, `attestation.subject`)
+- 3 response headers on page read (`CAP-Attestation-Type`, `CAP-Attestation-Subject-Kind`, `CAP-Attestation-Subject-Id`)
+- 1-2 meta tags in HTML
+- 1 field in JSON metadata (`attestation`)
+- 2 new LMDB indexes (`page:attestation-subject`, `page:attestation-type-subject`)
+- 1 new CAP header (`CAP-Attestation`)
+
+**Zero new endpoints.** Zero new services. Attestations are pages.
+
+## Design Decisions
+
+1. **Attestations are pages, not a separate entity.** No new storage, no new API surface. A page with an `attestation` field is just a page that makes a claim.
+
+2. **The signer IS the attester.** No separate identity assertion — `CAP-Key-Id` already tells you who made the claim. This is the simplest model that's still verifiable.
+
+3. **Subjects are identified by existing CAP identifiers.** Agent subjects use SHA-256 fingerprints (same as `recipientKeyId`). Asset subjects use signed page references (`{ownerKeyId}/{pageId}`) — stable across servers, not host-specific.
+
+4. **Claims are typed strings, not enums.** Well-known types are convention. Any agent can define new types. Unknown types are ignored by clients that don't understand them.
+
+5. **Attestations are not in the canonical request for signature verification.** The signature proves who published it. The attestation is metadata about the claim's meaning.
+
+6. **One attestation per page.** If you want to make multiple claims, publish multiple pages. Keeps things simple and queryable.
+
+7. **Revocation is a type, not a status field.** `type: "revoke"` is an attestation that cancels a previous one. Client-side logic determines which attestations are still valid.
+
+8. **Self-attestation is allowed.** Agents can make claims about themselves (capabilities, service endpoints, status). This is how agents describe themselves to the network.
+
+9. **No trust score baked in.** The protocol proves who said what. Deciding whether to trust them is a client-side policy. This avoids centralization and lets trust emerge organically.
+
+10. **Asset attestations use signed page references, not URLs.** A page's identity is `{ownerKeyId}/{pageId}` — stable across servers, deterministic, doesn't require knowing the host. URLs are server-specific; signed references are universal. If the same content is published by a different key, it's a different page with a different reference.
+
+11. **Attestation queries filter by subject or type+subject.** You can find all attestations about an agent, or all reviews of a page, or all trust claims. No full-text search needed — just indexes.
+
+## Resolved Questions
+
+1. **Asset subject identifiers**: Signed page references (`{ownerKeyId}/{pageId}`), not URLs. Stable across servers, deterministic, host-independent.
+
+2. **`metadata` size limit**: 2KB max. Sufficient for flat key-value pairs (~50+ pairs). The header path (base64url-encoded) adds ~33% overhead but stays well within typical 4-8KB per-header limits. The body path has no separate limit beyond overall page size.
+
+3. **No type registry**: Well-known types are convention-only. Extensible `type` string means custom types work without coordination. A registry can be added later if fragmentation becomes a problem, but the spec doesn't require one.
+
+4. **Attester filter is implementation detail**: The protocol specifies `attestation.type` and `attestation.subject` query filters. Services may add attester filtering as an implementation detail, but it's not required by the spec. Since the attester is `ownerKeyId`, existing owner-based listings can be filtered client-side.
+
+5. **Attestation chaining works naturally**: An attestation is a page, and pages can be subjects of other attestations. No special protocol support needed — it follows from the design. Chain depth and validation are client-side policy.

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { cors } from 'hono/cors';
 import { logger } from 'hono/logger';
 import dotenv from 'dotenv';
 import { config } from './config.js';
-import { initDatabase, closeDatabase, backfillOwnerIndex, backfillRecipientIndex, backfillKeyFingerprints } from './storage/db.js';
+import { initDatabase, closeDatabase, backfillOwnerIndex, backfillRecipientIndex, backfillKeyFingerprints, backfillAttestationIndexes } from './storage/db.js';
 import { initVideoStorage } from './storage/video.js';
 import { createServices, type Services } from './services/container.js';
 import { pages } from './routes/pages.js';
@@ -219,6 +219,12 @@ async function main() {
     const recipientBackfillResult = backfillRecipientIndex();
     if (recipientBackfillResult.indexed > 0 || recipientBackfillResult.skipped > 0) {
       console.log(`Recipient index backfill: ${recipientBackfillResult.indexed} indexed, ${recipientBackfillResult.skipped} skipped (no recipientKeyId)`);
+    }
+
+    // Backfill attestation indexes for pages that have attestation data
+    const attestationBackfillResult = backfillAttestationIndexes();
+    if (attestationBackfillResult.indexed > 0 || attestationBackfillResult.skipped > 0) {
+      console.log(`Attestation index backfill: ${attestationBackfillResult.indexed} indexed, ${attestationBackfillResult.skipped} skipped`);
     }
 
     // Backfill publicKeyFingerprint for keys that don't have one

--- a/src/routes/pages.ts
+++ b/src/routes/pages.ts
@@ -7,11 +7,11 @@ import { ErrorCodes, errorResponse } from '../errors.js';
 import { generateEtag } from '../utils/etag.js';
 import { isValidFingerprint } from '../utils/fingerprint.js';
 import { generateUrlToken, hashPassword, parseBasicAuth, verifyPassword } from '../utils/auth.js';
-import { decodeHtml, decodeMarkdown, validateAuthInput, validateId, validatePageBody } from '../utils/validation.js';
+import { decodeHtml, decodeMarkdown, validateAuthInput, validateId, validatePageBody, validateAttestation } from '../utils/validation.js';
 import { trackApiCall, trackPageCreated, trackPageDeleted, trackPageUpdated } from '../analytics/posthog.js';
 import { validateSubdomainName } from './subdomains.js';
 import type { Services } from '../services/container.js';
-import type { Page } from '../types.js';
+import type { Page, Attestation } from '../types.js';
 
 const pages = new Hono();
 
@@ -43,6 +43,7 @@ interface CreatePageBody {
     signToRead?: boolean;
   } | null;
   recipientKeyId?: string;
+  attestation?: Attestation | null;
 }
 
 pages.use('*', requireSignedAgent);
@@ -60,7 +61,19 @@ pages.get('/', requireSignedAgentForGet, (c) => {
   const since = c.req.query('since') || undefined;
 
   let result;
-  if (recipientParam === 'me') {
+  const attestationSubject = c.req.query('attestation.subject');
+  const attestationType = c.req.query('attestation.type');
+
+  if (attestationSubject && attestationType) {
+    // Query by type AND subject
+    result = services.pages.listAttestationsByTypeAndSubject(attestationType, attestationSubject, cursor, limit, since);
+  } else if (attestationSubject) {
+    // Query by subject only
+    result = services.pages.listAttestationsBySubject(attestationSubject, cursor, limit, since);
+  } else if (attestationType) {
+    // Type-only query is not supported (would need type-only index)
+    return errorResponse(ErrorCodes.INVALID_REQUEST, 'attestation.type requires attestation.subject — type-only queries are not supported', 400);
+  } else if (recipientParam === 'me') {
     // recipient=me resolves to the authenticated key's fingerprint
     const recipientFingerprint = keyFingerprint || keyId;
     result = services.pages.listByRecipient(recipientFingerprint, cursor, limit, since);
@@ -99,6 +112,10 @@ pages.get('/', requireSignedAgentForGet, (c) => {
 
     if (p.recipientKeyId) {
       item.recipientKeyId = p.recipientKeyId;
+    }
+
+    if (p.attestation) {
+      item.attestation = p.attestation;
     }
 
     return item;
@@ -333,6 +350,37 @@ pages.post('/:id', async (c) => {
     return errorResponse(ErrorCodes.PAGE_INVALID_AUTH, 'auth.signToRead requires recipientKeyId', 400);
   }
 
+  // Extract attestation from header (priority) or body
+  // CAP-Attestation header is base64url-encoded JSON
+  // X-Zenbin-Attestation is the legacy alias
+  // null in body means "remove attestation"
+  let attestation: Attestation | null | undefined;
+  const capAttestationHeader = c.req.header('CAP-Attestation') ?? c.req.header('X-Zenbin-Attestation');
+  if (capAttestationHeader !== undefined) {
+    // Header present: decode base64url JSON
+    try {
+      const decoded = Buffer.from(capAttestationHeader, 'base64url').toString('utf-8');
+      const parsed = JSON.parse(decoded);
+      attestation = parsed;
+    } catch {
+      return errorResponse(ErrorCodes.INVALID_REQUEST, 'CAP-Attestation header must be valid base64url-encoded JSON', 400);
+    }
+  } else if (body.attestation !== undefined) {
+    // Body field present: use its value (null = remove)
+    attestation = body.attestation;
+  } else {
+    // Neither provided: keep existing value
+    attestation = undefined;
+  }
+
+  // Validate attestation if present (not null and not undefined)
+  if (attestation && attestation !== null) {
+    const attError = validateAttestation(attestation);
+    if (attError) {
+      return errorResponse(ErrorCodes.INVALID_REQUEST, attError.message, 400);
+    }
+  }
+
   const { page, created } = await services.pages.save(
     id,
     {
@@ -355,6 +403,7 @@ pages.post('/:id', async (c) => {
       publishMethod,
       publishPath,
       recipientKeyId,
+      attestation,
       status: 'active',
     },
     etag,
@@ -376,7 +425,7 @@ pages.post('/:id', async (c) => {
   const subdomainOrigin = subdomain ? `${protocol}://${subdomain}.${domain}` : undefined;
   const pageUrl = subdomain ? `${subdomainOrigin}${subdomainPath}` : `${baseUrl}/p/${page.id}`;
 
-  const response: Record<string, string> = {
+  const response: Record<string, unknown> = {
     id: page.id,
     url: pageUrl,
     etag: page.etag,
@@ -407,6 +456,10 @@ pages.post('/:id', async (c) => {
 
   if (page.recipientKeyId) {
     response.recipientKeyId = page.recipientKeyId;
+  }
+
+  if (page.attestation) {
+    response.attestation = page.attestation;
   }
 
   if (subdomain) {

--- a/src/routes/render.ts
+++ b/src/routes/render.ts
@@ -218,6 +218,10 @@ render.get('/:id', async (c) => {
       response.recipientKeyId = page.recipientKeyId;
     }
 
+    if (page.attestation) {
+      response.attestation = page.attestation;
+    }
+
     c.header('ETag', jsonEtag);
     c.header('Cache-Control', 'public, max-age=0, must-revalidate');
     trackRequestView(c, id);

--- a/src/services/interfaces.ts
+++ b/src/services/interfaces.ts
@@ -42,6 +42,7 @@ export interface IPageService {
     publishMethod?: string;
     publishPath?: string;
     recipientKeyId?: string | null;
+    attestation?: import('../types.js').Attestation | null;
     status?: 'active' | 'removed';
   }, etag: string): Promise<SaveResult>;
 
@@ -68,6 +69,10 @@ export interface IPageService {
 
   // Recipient-based listing
   listByRecipient(recipientKeyId: string, cursor?: string, limit?: number, since?: string): { pages: PageSummary[]; total: number; next_cursor: string | null };
+
+  // Attestation-based listing
+  listAttestationsBySubject(subjectId: string, cursor?: string, limit?: number, since?: string): { pages: PageSummary[]; total: number; next_cursor: string | null };
+  listAttestationsByTypeAndSubject(type: string, subjectId: string, cursor?: string, limit?: number, since?: string): { pages: PageSummary[]; total: number; next_cursor: string | null };
 }
 
 // ─── Subdomain Service ──────────────────────────────────────

--- a/src/services/pageService.ts
+++ b/src/services/pageService.ts
@@ -14,6 +14,8 @@ import {
   listPagesBySubdomainPaginated as dbListPagesBySubdomainPaginated,
   listPagesByOwner as dbListPagesByOwner,
   listPagesByRecipient as dbListPagesByRecipient,
+  listAttestationsBySubject as dbListAttestationsBySubject,
+  listAttestationsByTypeAndSubject as dbListAttestationsByTypeAndSubject,
   incrementAgentKeyUsage,
   decrementSubdomainPageCount as dbDecrementSubdomainPageCount,
   incrementSubdomainPageCount as dbIncrementSubdomainPageCount,
@@ -51,6 +53,7 @@ export class PageService implements IPageService {
       publishMethod?: string;
       publishPath?: string;
       recipientKeyId?: string | null;
+      attestation?: import('../types.js').Attestation | null;
       status?: 'active' | 'removed';
     },
     etag: string,
@@ -176,5 +179,19 @@ export class PageService implements IPageService {
    */
   listByRecipient(recipientKeyId: string, cursor?: string, limit?: number, since?: string): { pages: PageSummary[]; total: number; next_cursor: string | null } {
     return dbListPagesByRecipient(recipientKeyId, cursor, limit, since);
+  }
+
+  /**
+   * List attestations by subject.
+   */
+  listAttestationsBySubject(subjectId: string, cursor?: string, limit?: number, since?: string): { pages: PageSummary[]; total: number; next_cursor: string | null } {
+    return dbListAttestationsBySubject(subjectId, cursor, limit, since);
+  }
+
+  /**
+   * List attestations by type and subject.
+   */
+  listAttestationsByTypeAndSubject(type: string, subjectId: string, cursor?: string, limit?: number, since?: string): { pages: PageSummary[]; total: number; next_cursor: string | null } {
+    return dbListAttestationsByTypeAndSubject(type, subjectId, cursor, limit, since);
   }
 }

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -12,6 +12,7 @@ import type {
   SubdomainResult,
   Plan,
   StoredJwk,
+  Attestation,
 } from '../types.js';
 
 // Re-export types for backward compatibility
@@ -26,6 +27,7 @@ export type {
   SubdomainResult,
   Plan,
   StoredJwk,
+  Attestation,
 };
 
 let db: Database<Page, string>;
@@ -35,6 +37,8 @@ let nonceDb: Database<NonceRecord, string>;
 let auditLogDb: Database<AuditLogRecord, string>;
 let ownerIndexDb: Database<PageSummary, string>;
 let recipientIndexDb: Database<PageSummary, string>;
+let attestationSubjectIndexDb: Database<PageSummary, string>;
+let attestationTypeSubjectIndexDb: Database<PageSummary, string>;
 
 // PageSummary — lightweight metadata for listing, never includes content
 export interface PageSummary {
@@ -47,6 +51,7 @@ export interface PageSummary {
   has_video: boolean;
   ownerKeyId: string;
   recipientKeyId?: string;
+  attestation?: import('../types.js').Attestation;
   created_at: string;
   updated_at: string;
   etag: string;
@@ -60,6 +65,8 @@ export function initDatabase(): {
   auditLogs: Database<AuditLogRecord, string>;
   ownerIndex: Database<PageSummary, string>;
   recipientIndex: Database<PageSummary, string>;
+  attestationSubjectIndex: Database<PageSummary, string>;
+  attestationTypeSubjectIndex: Database<PageSummary, string>;
 } {
   if (!db) {
     db = open<Page, string>({
@@ -103,6 +110,18 @@ export function initDatabase(): {
       compression: true,
     });
   }
+  if (!attestationSubjectIndexDb) {
+    attestationSubjectIndexDb = open<PageSummary, string>({
+      path: `${config.lmdbPath}-attestation-subject-index`,
+      compression: true,
+    });
+  }
+  if (!attestationTypeSubjectIndexDb) {
+    attestationTypeSubjectIndexDb = open<PageSummary, string>({
+      path: `${config.lmdbPath}-attestation-type-subject-index`,
+      compression: true,
+    });
+  }
 
   return {
     pages: db,
@@ -112,6 +131,8 @@ export function initDatabase(): {
     auditLogs: auditLogDb,
     ownerIndex: ownerIndexDb,
     recipientIndex: recipientIndexDb,
+    attestationSubjectIndex: attestationSubjectIndexDb,
+    attestationTypeSubjectIndex: attestationTypeSubjectIndexDb,
   };
 }
 
@@ -268,6 +289,20 @@ export function getRecipientIndexDatabase(): Database<PageSummary, string> {
   return recipientIndexDb;
 }
 
+export function getAttestationSubjectIndexDatabase(): Database<PageSummary, string> {
+  if (!attestationSubjectIndexDb) {
+    throw new Error('Database not initialized. Call initDatabase() first.');
+  }
+  return attestationSubjectIndexDb;
+}
+
+export function getAttestationTypeSubjectIndexDatabase(): Database<PageSummary, string> {
+  if (!attestationTypeSubjectIndexDb) {
+    throw new Error('Database not initialized. Call initDatabase() first.');
+  }
+  return attestationTypeSubjectIndexDb;
+}
+
 function pageStorageKey(id: string, subdomain?: string): string {
   return subdomain ? `${subdomain}:${id}` : id;
 }
@@ -302,6 +337,7 @@ export async function savePage(
     publishMethod?: string;
     publishPath?: string;
     recipientKeyId?: string | null;
+    attestation?: import('../types.js').Attestation | null;
     status?: 'active' | 'removed';
   },
   etag: string,
@@ -336,6 +372,7 @@ export async function savePage(
     publishMethod: data.publishMethod || existing?.publishMethod,
     publishPath: data.publishPath || existing?.publishPath,
     recipientKeyId: data.recipientKeyId === null ? undefined : (data.recipientKeyId !== undefined ? data.recipientKeyId : existing?.recipientKeyId),
+    attestation: data.attestation === null ? undefined : (data.attestation !== undefined ? data.attestation : existing?.attestation),
     status: data.status || existing?.status || 'active',
   };
 
@@ -349,6 +386,14 @@ export async function savePage(
     removePageFromRecipientIndex(existing);
   }
   addPageToRecipientIndex(page);
+
+  // Update attestation indexes: remove old if changed, add new if present
+  if (existing?.attestation && existing.attestation !== page.attestation) {
+    removePageFromAttestationIndexes(existing);
+  }
+  if (page.attestation) {
+    addPageToAttestationIndexes(page);
+  }
 
   return {
     page,
@@ -374,6 +419,11 @@ export async function deletePage(id: string, subdomain?: string): Promise<boolea
 
   // Remove from recipient index
   removePageFromRecipientIndex(existing);
+
+  // Remove from attestation indexes
+  if (existing.attestation) {
+    removePageFromAttestationIndexes(existing);
+  }
 
   return true;
 }
@@ -437,6 +487,7 @@ export function listPagesBySubdomainPaginated(
           has_video: !!page.video,
           ownerKeyId: page.ownerKeyId || '',
           recipientKeyId: page.recipientKeyId,
+          attestation: page.attestation,
           created_at: page.created_at,
           updated_at: page.updated_at,
           etag: page.etag,
@@ -694,6 +745,7 @@ export function addPageToOwnerIndex(page: Page): void {
     has_video: !!page.video,
     ownerKeyId: page.ownerKeyId,
     recipientKeyId: page.recipientKeyId,
+    attestation: page.attestation,
     created_at: page.created_at,
     updated_at: page.updated_at,
     etag: page.etag,
@@ -774,6 +826,7 @@ export function addPageToRecipientIndex(page: Page): void {
     has_video: !!page.video,
     ownerKeyId: page.ownerKeyId || '',
     recipientKeyId: page.recipientKeyId,
+    attestation: page.attestation,
     created_at: page.created_at,
     updated_at: page.updated_at,
     etag: page.etag,
@@ -831,6 +884,173 @@ export function listPagesByRecipient(
   const nextCursor = total > pages.length && lastPage ? `${recipientKeyId}/${lastPage.subdomain ? lastPage.subdomain + ':' : ''}${lastPage.id}` : null;
 
   return { pages, total, next_cursor: nextCursor };
+}
+
+// ─── Attestation Indexes ────────────────────────────────────
+
+function attestationSubjectIndexKey(page: Page): string {
+  const subjectId = page.attestation!.subject.id;
+  const ownerKeyId = page.ownerKeyId || '';
+  return `${encodeURIComponent(subjectId)}:${ownerKeyId}`;
+}
+
+function attestationTypeSubjectIndexKey(page: Page): string {
+  const att = page.attestation!;
+  const subjectId = att.subject.id;
+  const ownerKeyId = page.ownerKeyId || '';
+  return `${att.type}:${encodeURIComponent(subjectId)}:${ownerKeyId}`;
+}
+
+export function addPageToAttestationIndexes(page: Page): void {
+  if (!page.attestation || !page.ownerKeyId) return;
+
+  const summary: PageSummary = {
+    id: page.id,
+    subdomain: page.subdomain ?? null,
+    title: page.title,
+    content_type: page.content_type,
+    has_markdown: !!page.markdown,
+    has_image: !!page.image,
+    has_video: !!page.video,
+    ownerKeyId: page.ownerKeyId,
+    recipientKeyId: page.recipientKeyId,
+    attestation: page.attestation,
+    created_at: page.created_at,
+    updated_at: page.updated_at,
+    etag: page.etag,
+  };
+
+  const subjectKey = attestationSubjectIndexKey(page);
+  getAttestationSubjectIndexDatabase().putSync(subjectKey, summary);
+
+  const typeSubjectKey = attestationTypeSubjectIndexKey(page);
+  getAttestationTypeSubjectIndexDatabase().putSync(typeSubjectKey, summary);
+}
+
+export function removePageFromAttestationIndexes(page: Page): void {
+  if (!page.attestation || !page.ownerKeyId) return;
+
+  const subjectKey = attestationSubjectIndexKey(page);
+  try {
+    getAttestationSubjectIndexDatabase().removeSync(subjectKey);
+  } catch {
+    // Key may not exist
+  }
+
+  const typeSubjectKey = attestationTypeSubjectIndexKey(page);
+  try {
+    getAttestationTypeSubjectIndexDatabase().removeSync(typeSubjectKey);
+  } catch {
+    // Key may not exist
+  }
+}
+
+export function listAttestationsBySubject(
+  subjectId: string,
+  cursor?: string,
+  limit: number = 50,
+  since?: string,
+): { pages: PageSummary[]; total: number; next_cursor: string | null } {
+  const idxDb = getAttestationSubjectIndexDatabase();
+  const encodedSubjectId = encodeURIComponent(subjectId);
+  const prefix = `${encodedSubjectId}:`;
+  const pages: PageSummary[] = [];
+  let total = 0;
+
+  for (const key of idxDb.getKeys({ start: prefix })) {
+    if (!key.startsWith(prefix)) break;
+
+    if (cursor && key <= cursor) {
+      continue;
+    }
+
+    const summary = idxDb.get(key);
+    if (!summary) continue;
+
+    // Apply since filter (inclusive)
+    if (since && summary.created_at < since) continue;
+
+    total++;
+    if (pages.length < limit) {
+      pages.push(summary);
+    }
+  }
+
+  const lastPage = pages.length > 0 ? pages[pages.length - 1] : null;
+  const nextCursor = total > pages.length && lastPage
+    ? `${encodedSubjectId}:${lastPage.ownerKeyId}`
+    : null;
+
+  return { pages, total, next_cursor: nextCursor };
+}
+
+export function listAttestationsByTypeAndSubject(
+  type: string,
+  subjectId: string,
+  cursor?: string,
+  limit: number = 50,
+  since?: string,
+): { pages: PageSummary[]; total: number; next_cursor: string | null } {
+  const idxDb = getAttestationTypeSubjectIndexDatabase();
+  const encodedSubjectId = encodeURIComponent(subjectId);
+  const prefix = `${type}:${encodedSubjectId}:`;
+  const pages: PageSummary[] = [];
+  let total = 0;
+
+  for (const key of idxDb.getKeys({ start: prefix })) {
+    if (!key.startsWith(prefix)) break;
+
+    if (cursor && key <= cursor) {
+      continue;
+    }
+
+    const summary = idxDb.get(key);
+    if (!summary) continue;
+
+    // Apply since filter (inclusive)
+    if (since && summary.created_at < since) continue;
+
+    total++;
+    if (pages.length < limit) {
+      pages.push(summary);
+    }
+  }
+
+  const lastPage = pages.length > 0 ? pages[pages.length - 1] : null;
+  const nextCursor = total > pages.length && lastPage
+    ? `${type}:${encodedSubjectId}:${lastPage.ownerKeyId}`
+    : null;
+
+  return { pages, total, next_cursor: nextCursor };
+}
+
+export function backfillAttestationIndexes(): { indexed: number; skipped: number } {
+  const pagesDb = getDatabase();
+  let indexed = 0;
+  let skipped = 0;
+
+  for (const key of pagesDb.getKeys({})) {
+    const page = pagesDb.get(key);
+    if (!page) continue;
+
+    if (!page.attestation || !page.ownerKeyId) {
+      skipped++;
+      continue;
+    }
+
+    // Check if already indexed
+    const subjectKey = attestationSubjectIndexKey(page);
+    const idxDb = getAttestationSubjectIndexDatabase();
+    const existing = idxDb.get(subjectKey);
+    if (existing) {
+      continue; // Already indexed
+    }
+
+    addPageToAttestationIndexes(page);
+    indexed++;
+  }
+
+  return { indexed, skipped };
 }
 
 // ─── Billing-Related Storage ───────────────────────────────
@@ -911,5 +1131,13 @@ export async function closeDatabase(): Promise<void> {
   if (recipientIndexDb) {
     await recipientIndexDb.close();
     recipientIndexDb = undefined as unknown as Database<PageSummary, string>;
+  }
+  if (attestationSubjectIndexDb) {
+    await attestationSubjectIndexDb.close();
+    attestationSubjectIndexDb = undefined as unknown as Database<PageSummary, string>;
+  }
+  if (attestationTypeSubjectIndexDb) {
+    await attestationTypeSubjectIndexDb.close();
+    attestationTypeSubjectIndexDb = undefined as unknown as Database<PageSummary, string>;
   }
 }

--- a/src/test/cap-attestation.test.ts
+++ b/src/test/cap-attestation.test.ts
@@ -1,0 +1,783 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import { pages } from '../routes/pages.js';
+import { render } from '../routes/render.js';
+import { subdomains } from '../routes/subdomains.js';
+import { keys } from '../routes/keys.js';
+import { verify } from '../routes/verify.js';
+import { initDatabase, closeDatabase, backfillAttestationIndexes } from '../storage/db.js';
+import { createServices, type Services } from '../services/container.js';
+import { rmSync } from 'fs';
+import { validateAttestation, isValidSignedPageRef } from '../utils/validation.js';
+import { createTestSigner, jsonSignedRequest, jsonCapSignedRequest, createSignedHeaders, type TestSigner } from './helpers/signing.js';
+
+const TEST_DB_PATH = './data/test-cap-attestation.lmdb';
+const TEST_DB_SUFFIXES = [
+  '', '-subdomains', '-agent-keys', '-nonces', '-audit',
+  '-owner-index', '-recipient-index',
+  '-attestation-subject-index', '-attestation-type-subject-index',
+];
+
+const services = createServices();
+const app = new Hono<{ Variables: { subdomain: string; services: Services } }>();
+app.use('*', async (c, next) => {
+  c.set('services', services);
+  await next();
+});
+app.route('/v1/pages', pages);
+app.route('/v1/subdomains', subdomains);
+app.route('/p', render);
+app.route('/v1/keys', keys);
+app.route('/v1/verify', verify);
+
+let testId: number;
+const uniqueId = (base: string) => `${base}-${testId++}`;
+let alice: TestSigner;
+let bob: TestSigner;
+let carol: TestSigner;
+
+function signedGet(signer: TestSigner, path: string): Request {
+  const timestamp = new Date().toISOString();
+  const nonce = `nonce-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const pathForSigning = path.split('?')[0];
+  const headers = createSignedHeaders({
+    signer,
+    method: 'GET',
+    path: pathForSigning,
+    body: '',
+    timestamp,
+    nonce,
+  });
+  return new Request(`http://localhost${path}`, { method: 'GET', headers });
+}
+
+function toBase64Url(str: string): string {
+  return Buffer.from(str).toString('base64url');
+}
+
+beforeAll(async () => {
+  for (const suffix of TEST_DB_SUFFIXES) {
+    try { rmSync(`${TEST_DB_PATH}${suffix}`, { recursive: true, force: true }); } catch {}
+  }
+  process.env.LMDB_PATH = TEST_DB_PATH;
+  initDatabase();
+  alice = await createTestSigner(`cap-att-alice-${Date.now()}`);
+  bob = await createTestSigner(`cap-att-bob-${Date.now()}`);
+  carol = await createTestSigner(`cap-att-carol-${Date.now()}`);
+
+  // Upgrade to enterprise to avoid billing limits
+  const { updateAgentKeyPlan } = await import('../storage/db.js');
+  await updateAgentKeyPlan(alice.keyId, 'enterprise');
+  await updateAgentKeyPlan(bob.keyId, 'enterprise');
+  await updateAgentKeyPlan(carol.keyId, 'enterprise');
+});
+
+beforeEach(() => {
+  testId = Date.now();
+});
+
+afterAll(async () => {
+  await closeDatabase();
+  for (const suffix of TEST_DB_SUFFIXES) {
+    try { rmSync(`${TEST_DB_PATH}${suffix}`, { recursive: true, force: true }); } catch {}
+  }
+});
+
+// ─── Group 1: Validation ──────────────────────────────────
+
+describe('Validation', () => {
+  it('should accept a valid attestation with agent subject', () => {
+    const attestation = {
+      type: 'verify',
+      subject: { kind: 'agent' as const, id: 'HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0' },
+      context: 'Identity verified through domain control proof',
+    };
+    expect(validateAttestation(attestation)).toBeNull();
+  });
+
+  it('should accept a valid attestation with asset subject', () => {
+    const attestation = {
+      type: 'review',
+      subject: { kind: 'asset' as const, id: 'agent-alice-123/my-analysis' },
+    };
+    expect(validateAttestation(attestation)).toBeNull();
+  });
+
+  it('should accept attestation with optional fields', () => {
+    const attestation = {
+      type: 'trust',
+      subject: { kind: 'agent' as const, id: 'HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0' },
+      context: 'Trusted for code review',
+      metadata: { scope: 'code-review', level: 'full' },
+      timestamp: '2026-06-05T09:00:00Z',
+    };
+    expect(validateAttestation(attestation)).toBeNull();
+  });
+
+  it('should reject attestation missing type', () => {
+    const attestation = {
+      subject: { kind: 'agent' as const, id: 'HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0' },
+    };
+    expect(validateAttestation(attestation)).not.toBeNull();
+    expect(validateAttestation(attestation)!.field).toBe('attestation.type');
+  });
+
+  it('should reject attestation missing subject', () => {
+    const attestation = { type: 'verify' };
+    expect(validateAttestation(attestation)).not.toBeNull();
+    expect(validateAttestation(attestation)!.field).toBe('attestation.subject');
+  });
+
+  it('should reject attestation with invalid subject kind', () => {
+    const attestation = {
+      type: 'verify',
+      subject: { kind: 'organization' as any, id: 'HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0' },
+    };
+    expect(validateAttestation(attestation)).not.toBeNull();
+    expect(validateAttestation(attestation)!.field).toBe('attestation.subject.kind');
+  });
+
+  it('should reject agent subject with bad fingerprint (not 43 chars)', () => {
+    const attestation = {
+      type: 'verify',
+      subject: { kind: 'agent' as const, id: 'short-id' },
+    };
+    expect(validateAttestation(attestation)).not.toBeNull();
+    expect(validateAttestation(attestation)!.field).toBe('attestation.subject.id');
+  });
+
+  it('should reject asset subject with bad signed page ref (no slash)', () => {
+    const attestation = {
+      type: 'review',
+      subject: { kind: 'asset' as const, id: 'noslash' },
+    };
+    expect(validateAttestation(attestation)).not.toBeNull();
+  });
+
+  it('should reject oversized context (>500 chars)', () => {
+    const attestation = {
+      type: 'verify',
+      subject: { kind: 'agent' as const, id: 'HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0' },
+      context: 'x'.repeat(501),
+    };
+    expect(validateAttestation(attestation)).not.toBeNull();
+    expect(validateAttestation(attestation)!.field).toBe('attestation.context');
+  });
+
+  it('should reject nested metadata values', () => {
+    const attestation = {
+      type: 'verify',
+      subject: { kind: 'agent' as const, id: 'HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0' },
+      metadata: { nested: { deep: 'value' } },
+    };
+    expect(validateAttestation(attestation)).not.toBeNull();
+    expect(validateAttestation(attestation)!.field).toBe('attestation.metadata');
+  });
+
+  it('should reject array metadata values', () => {
+    const attestation = {
+      type: 'verify',
+      subject: { kind: 'agent' as const, id: 'HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0' },
+      metadata: { scope: ['read', 'write'] },
+    };
+    expect(validateAttestation(attestation)).not.toBeNull();
+  });
+
+  it('should reject invalid timestamp', () => {
+    const attestation = {
+      type: 'verify',
+      subject: { kind: 'agent' as const, id: 'HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0' },
+      timestamp: 'not-a-date',
+    };
+    expect(validateAttestation(attestation)).not.toBeNull();
+    expect(validateAttestation(attestation)!.field).toBe('attestation.timestamp');
+  });
+});
+
+// ─── isValidSignedPageRef ─────────────────────────────────
+
+describe('isValidSignedPageRef', () => {
+  it('should accept valid signed page refs', () => {
+    expect(isValidSignedPageRef('agent-alice-123/my-page')).toBe(true);
+    expect(isValidSignedPageRef('key_456/analysis')).toBe(true);
+    expect(isValidSignedPageRef('a/b')).toBe(true);
+  });
+
+  it('should reject refs without slash', () => {
+    expect(isValidSignedPageRef('noslash')).toBe(false);
+  });
+
+  it('should reject refs with empty segments', () => {
+    expect(isValidSignedPageRef('/page')).toBe(false);
+    expect(isValidSignedPageRef('owner/')).toBe(false);
+    expect(isValidSignedPageRef('/')).toBe(false);
+  });
+
+  it('should reject refs with multiple slashes', () => {
+    expect(isValidSignedPageRef('owner/path/page')).toBe(false);
+  });
+
+  it('should reject refs with special chars', () => {
+    expect(isValidSignedPageRef('own er/page')).toBe(false);
+    expect(isValidSignedPageRef('owner/pa ge')).toBe(false);
+  });
+});
+
+// ─── Group 2: Publish with attestation (body) ──────────────
+
+describe('Publish with attestation (body)', () => {
+  it('should publish a page with attestation in body', async () => {
+    const id = uniqueId('att-body');
+    const attestation = {
+      type: 'verify',
+      subject: { kind: 'agent', id: bob.publicKeyFingerprint },
+      context: 'Identity verified',
+    };
+    const res = await app.request(`/v1/pages/${id}`, jsonSignedRequest({
+      signer: alice,
+      method: 'POST',
+      path: `/v1/pages/${id}`,
+      body: { html: '<h1>Verified</h1>', attestation },
+    }));
+    expect(res.status).toBe(201);
+    const data = await res.json() as any;
+    expect(data.attestation).toBeDefined();
+    expect(data.attestation.type).toBe('verify');
+    expect(data.attestation.subject.kind).toBe('agent');
+    expect(data.attestation.subject.id).toBe(bob.publicKeyFingerprint);
+    expect(data.attestation.context).toBe('Identity verified');
+  });
+
+  it('should return attestation in GET response', async () => {
+    const id = uniqueId('att-get');
+    const attestation = {
+      type: 'trust',
+      subject: { kind: 'agent', id: carol.publicKeyFingerprint },
+    };
+    await app.request(`/v1/pages/${id}`, jsonSignedRequest({
+      signer: alice,
+      method: 'POST',
+      path: `/v1/pages/${id}`,
+      body: { html: '<h1>Trusted</h1>', attestation },
+    }));
+
+    const listRes = await app.request(signedGet(alice, '/v1/pages'));
+    expect(listRes.status).toBe(200);
+    const data = await listRes.json() as any;
+    const found = data.pages.find((p: any) => p.id === id);
+    expect(found).toBeDefined();
+    expect(found.attestation).toBeDefined();
+    expect(found.attestation.type).toBe('trust');
+  });
+});
+
+// ─── Group 3: Publish with attestation (header) ─────────────
+
+describe('Publish with attestation (header)', () => {
+  it('should publish with CAP-Attestation header (base64url)', async () => {
+    const id = uniqueId('att-hdr');
+    const attestation = {
+      type: 'endorse',
+      subject: { kind: 'asset', id: `${alice.keyId}/my-analysis` },
+      context: 'Great analysis',
+    };
+    const headerValue = toBase64Url(JSON.stringify(attestation));
+    const res = await app.request(`/v1/pages/${id}`, jsonSignedRequest({
+      signer: alice,
+      method: 'POST',
+      path: `/v1/pages/${id}`,
+      body: { html: '<h1>Endorsed</h1>' },
+      headers: { 'CAP-Attestation': headerValue },
+    }));
+    expect(res.status).toBe(201);
+    const data = await res.json() as any;
+    expect(data.attestation).toBeDefined();
+    expect(data.attestation.type).toBe('endorse');
+    expect(data.attestation.subject.kind).toBe('asset');
+  });
+
+  it('should accept X-Zenbin-Attestation legacy header', async () => {
+    const id = uniqueId('att-legacy-hdr');
+    const attestation = {
+      type: 'flag',
+      subject: { kind: 'asset', id: `${bob.keyId}/suspicious-page` },
+      context: 'Contains unverified claims',
+    };
+    const headerValue = toBase64Url(JSON.stringify(attestation));
+    const res = await app.request(`/v1/pages/${id}`, jsonSignedRequest({
+      signer: alice,
+      method: 'POST',
+      path: `/v1/pages/${id}`,
+      body: { html: '<h1>Flagged</h1>' },
+      headers: { 'X-Zenbin-Attestation': headerValue },
+    }));
+    expect(res.status).toBe(201);
+    const data = await res.json() as any;
+    expect(data.attestation).toBeDefined();
+    expect(data.attestation.type).toBe('flag');
+  });
+
+  it('should prioritize CAP-Attestation header over body', async () => {
+    const id = uniqueId('att-priority');
+    const headerAttestation = {
+      type: 'verify',
+      subject: { kind: 'agent', id: bob.publicKeyFingerprint },
+      context: 'From header',
+    };
+    const bodyAttestation = {
+      type: 'trust',
+      subject: { kind: 'agent', id: carol.publicKeyFingerprint },
+      context: 'From body',
+    };
+    const headerValue = toBase64Url(JSON.stringify(headerAttestation));
+    const res = await app.request(`/v1/pages/${id}`, jsonSignedRequest({
+      signer: alice,
+      method: 'POST',
+      path: `/v1/pages/${id}`,
+      body: { html: '<h1>Priority</h1>', attestation: bodyAttestation },
+      headers: { 'CAP-Attestation': headerValue },
+    }));
+    expect(res.status).toBe(201);
+    const data = await res.json() as any;
+    expect(data.attestation.type).toBe('verify');
+    expect(data.attestation.context).toBe('From header');
+  });
+
+  it('should reject invalid base64url in CAP-Attestation header', async () => {
+    const id = uniqueId('att-bad-hdr');
+    const res = await app.request(`/v1/pages/${id}`, jsonSignedRequest({
+      signer: alice,
+      method: 'POST',
+      path: `/v1/pages/${id}`,
+      body: { html: '<h1>Bad Header</h1>' },
+      headers: { 'CAP-Attestation': 'not-valid-base64!!!' },
+    }));
+    expect(res.status).toBe(400);
+  });
+});
+
+// ─── Group 4: Attestation indexing ──────────────────────────
+
+describe('Attestation indexing', () => {
+  it('should create attestation indexes on publish', async () => {
+    const id = uniqueId('att-idx');
+    const attestation = {
+      type: 'verify',
+      subject: { kind: 'agent', id: bob.publicKeyFingerprint },
+    };
+    await app.request(`/v1/pages/${id}`, jsonSignedRequest({
+      signer: alice,
+      method: 'POST',
+      path: `/v1/pages/${id}`,
+      body: { html: '<h1>Indexed</h1>', attestation },
+    }));
+
+    // Query by subject should find it
+    const listRes = await app.request(signedGet(alice, `/v1/pages?attestation.subject=${bob.publicKeyFingerprint}`));
+    expect(listRes.status).toBe(200);
+    const data = await listRes.json() as any;
+    expect(data.pages.some((p: any) => p.id === id)).toBe(true);
+  });
+
+  it('should remove attestation indexes when attestation is set to null', async () => {
+    const id = uniqueId('att-remove');
+    const attestation = {
+      type: 'verify',
+      subject: { kind: 'agent', id: carol.publicKeyFingerprint },
+    };
+    await app.request(`/v1/pages/${id}`, jsonSignedRequest({
+      signer: alice,
+      method: 'POST',
+      path: `/v1/pages/${id}`,
+      body: { html: '<h1>To Remove</h1>', attestation },
+    }));
+
+    // Should appear in query
+    let listRes = await app.request(signedGet(alice, `/v1/pages?attestation.subject=${carol.publicKeyFingerprint}`));
+    let data = await listRes.json() as any;
+    expect(data.pages.some((p: any) => p.id === id)).toBe(true);
+
+    // Remove attestation by setting to null
+    await app.request(`/v1/pages/${id}`, jsonSignedRequest({
+      signer: alice,
+      method: 'POST',
+      path: `/v1/pages/${id}`,
+      body: { html: '<h1>No Attestation</h1>', attestation: null },
+    }));
+
+    // Should no longer appear in attestation query
+    listRes = await app.request(signedGet(alice, `/v1/pages?attestation.subject=${carol.publicKeyFingerprint}`));
+    data = await listRes.json() as any;
+    expect(data.pages.some((p: any) => p.id === id)).toBe(false);
+  });
+
+  it('should update indexes when attestation changes', async () => {
+    const id = uniqueId('att-update');
+    const attestation1 = {
+      type: 'verify',
+      subject: { kind: 'agent', id: bob.publicKeyFingerprint },
+    };
+    const attestation2 = {
+      type: 'trust',
+      subject: { kind: 'agent', id: carol.publicKeyFingerprint },
+    };
+
+    // Publish with first attestation
+    await app.request(`/v1/pages/${id}`, jsonSignedRequest({
+      signer: alice,
+      method: 'POST',
+      path: `/v1/pages/${id}`,
+      body: { html: '<h1>Original</h1>', attestation: attestation1 },
+    }));
+
+    // Should appear in bob's attestation query
+    let listRes = await app.request(signedGet(alice, `/v1/pages?attestation.subject=${bob.publicKeyFingerprint}`));
+    let data = await listRes.json() as any;
+    expect(data.pages.some((p: any) => p.id === id)).toBe(true);
+
+    // Update with different attestation
+    await app.request(`/v1/pages/${id}`, jsonSignedRequest({
+      signer: alice,
+      method: 'POST',
+      path: `/v1/pages/${id}`,
+      body: { html: '<h1>Updated</h1>', attestation: attestation2 },
+    }));
+
+    // Should no longer appear in bob's query
+    listRes = await app.request(signedGet(alice, `/v1/pages?attestation.subject=${bob.publicKeyFingerprint}`));
+    data = await listRes.json() as any;
+    expect(data.pages.some((p: any) => p.id === id)).toBe(false);
+
+    // Should appear in carol's query
+    listRes = await app.request(signedGet(alice, `/v1/pages?attestation.subject=${carol.publicKeyFingerprint}`));
+    data = await listRes.json() as any;
+    expect(data.pages.some((p: any) => p.id === id)).toBe(true);
+  });
+});
+
+// ─── Group 5: One-per-agent-per-subject ─────────────────────
+
+describe('One-per-agent-per-subject', () => {
+  it('should overwrite index when same agent attests about same subject on different page', async () => {
+    const subject = bob.publicKeyFingerprint;
+    const id1 = uniqueId('att-overwrite1');
+    const id2 = uniqueId('att-overwrite2');
+
+    // Alice attests about Bob on page 1
+    await app.request(`/v1/pages/${id1}`, jsonSignedRequest({
+      signer: alice,
+      method: 'POST',
+      path: `/v1/pages/${id1}`,
+      body: { html: '<h1>Verify 1</h1>', attestation: { type: 'verify', subject: { kind: 'agent', id: subject } } },
+    }));
+
+    // Alice attests about Bob on page 2 (overwrites index)
+    await app.request(`/v1/pages/${id2}`, jsonSignedRequest({
+      signer: alice,
+      method: 'POST',
+      path: `/v1/pages/${id2}`,
+      body: { html: '<h1>Verify 2</h1>', attestation: { type: 'verify', subject: { kind: 'agent', id: subject } } },
+    }));
+
+    // Query should return the latest (page 2) since last-write-wins at index level
+    const listRes = await app.request(signedGet(alice, `/v1/pages?attestation.subject=${subject}`));
+    expect(listRes.status).toBe(200);
+    const data = await listRes.json() as any;
+    // The index should have the latest page for this agent+subject combo
+    expect(data.pages.length).toBeGreaterThanOrEqual(1);
+    // Find the entry from alice
+    const aliceEntries = data.pages.filter((p: any) => p.keyId === alice.keyId);
+    expect(aliceEntries.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ─── Group 6: Query endpoints ──────────────────────────────
+
+describe('Query endpoints', () => {
+  it('should query by attestation.subject (agent fingerprint)', async () => {
+    const id = uniqueId('att-q-agent');
+    const attestation = {
+      type: 'verify',
+      subject: { kind: 'agent', id: bob.publicKeyFingerprint },
+    };
+    await app.request(`/v1/pages/${id}`, jsonSignedRequest({
+      signer: alice,
+      method: 'POST',
+      path: `/v1/pages/${id}`,
+      body: { html: '<h1>Agent Query</h1>', attestation },
+    }));
+
+    const listRes = await app.request(signedGet(alice, `/v1/pages?attestation.subject=${bob.publicKeyFingerprint}`));
+    expect(listRes.status).toBe(200);
+    const data = await listRes.json() as any;
+    expect(data.pages.some((p: any) => p.id === id)).toBe(true);
+  });
+
+  it('should query by attestation.subject (asset signed page ref)', async () => {
+    const id = uniqueId('att-q-asset');
+    const assetRef = `${alice.keyId}/my-analysis`;
+    const attestation = {
+      type: 'review',
+      subject: { kind: 'asset', id: assetRef },
+    };
+    await app.request(`/v1/pages/${id}`, jsonSignedRequest({
+      signer: bob,
+      method: 'POST',
+      path: `/v1/pages/${id}`,
+      body: { html: '<h1>Asset Query</h1>', attestation },
+    }));
+
+    // URL-encode the slash in the subject
+    const listRes = await app.request(signedGet(bob, `/v1/pages?attestation.subject=${encodeURIComponent(assetRef)}`));
+    expect(listRes.status).toBe(200);
+    const data = await listRes.json() as any;
+    expect(data.pages.some((p: any) => p.id === id)).toBe(true);
+  });
+
+  it('should query by attestation.type AND attestation.subject', async () => {
+    const id = uniqueId('att-q-type-subj');
+    const attestation = {
+      type: 'endorse',
+      subject: { kind: 'asset', id: `${alice.keyId}/my-page` },
+    };
+    await app.request(`/v1/pages/${id}`, jsonSignedRequest({
+      signer: bob,
+      method: 'POST',
+      path: `/v1/pages/${id}`,
+      body: { html: '<h1>Type+Subject</h1>', attestation },
+    }));
+
+    const subject = `${alice.keyId}/my-page`;
+    const listRes = await app.request(signedGet(bob, `/v1/pages?attestation.type=endorse&attestation.subject=${encodeURIComponent(subject)}`));
+    expect(listRes.status).toBe(200);
+    const data = await listRes.json() as any;
+    expect(data.pages.some((p: any) => p.id === id)).toBe(true);
+  });
+
+  it('should return 400 for type-only query without subject', async () => {
+    const res = await app.request(signedGet(alice, '/v1/pages?attestation.type=verify'));
+    expect(res.status).toBe(400);
+    const data = await res.json() as any;
+    expect(data.error).toContain('attestation.type requires attestation.subject');
+  });
+
+  it('should include attestation field in query results', async () => {
+    const id = uniqueId('att-q-field');
+    const attestation = {
+      type: 'certify',
+      subject: { kind: 'asset', id: `${alice.keyId}/api-docs` },
+      context: 'Certified accurate',
+    };
+    await app.request(`/v1/pages/${id}`, jsonSignedRequest({
+      signer: carol,
+      method: 'POST',
+      path: `/v1/pages/${id}`,
+      body: { html: '<h1>Certified</h1>', attestation },
+    }));
+
+    const subject = `${alice.keyId}/api-docs`;
+    const listRes = await app.request(signedGet(carol, `/v1/pages?attestation.subject=${encodeURIComponent(subject)}`));
+    expect(listRes.status).toBe(200);
+    const data = await listRes.json() as any;
+    const found = data.pages.find((p: any) => p.id === id);
+    expect(found).toBeDefined();
+    expect(found.attestation).toBeDefined();
+    expect(found.attestation.type).toBe('certify');
+    expect(found.attestation.context).toBe('Certified accurate');
+  });
+
+  it('should support pagination with attestation queries', async () => {
+    const subject = bob.publicKeyFingerprint;
+    // Create multiple attestations about Bob
+    const ids = [uniqueId('att-page-1'), uniqueId('att-page-2'), uniqueId('att-page-3')];
+    for (const id of ids) {
+      await app.request(`/v1/pages/${id}`, jsonSignedRequest({
+        signer: alice,
+        method: 'POST',
+        path: `/v1/pages/${id}`,
+        body: { html: `<h1>Page ${id}</h1>`, attestation: { type: 'verify', subject: { kind: 'agent', id: subject } } },
+      }));
+    }
+
+    const listRes = await app.request(signedGet(alice, `/v1/pages?attestation.subject=${subject}&limit=2`));
+    expect(listRes.status).toBe(200);
+    const data = await listRes.json() as any;
+    expect(data.pages.length).toBeLessThanOrEqual(2);
+    // Should have a next_cursor if there are more results
+    if (data.total > 2) {
+      expect(data.next_cursor).not.toBeNull();
+    }
+  });
+
+  it('should support since filter with attestation queries', async () => {
+    const subject = carol.publicKeyFingerprint;
+    const id = uniqueId('att-since');
+    await app.request(`/v1/pages/${id}`, jsonSignedRequest({
+      signer: alice,
+      method: 'POST',
+      path: `/v1/pages/${id}`,
+      body: { html: '<h1>Since Filter</h1>', attestation: { type: 'trust', subject: { kind: 'agent', id: subject } } },
+    }));
+
+    // Query with since filter that should include this page
+    const since = '2020-01-01T00:00:00Z';
+    const listRes = await app.request(signedGet(alice, `/v1/pages?attestation.subject=${subject}&since=${since}`));
+    expect(listRes.status).toBe(200);
+    const data = await listRes.json() as any;
+    expect(data.pages.some((p: any) => p.id === id)).toBe(true);
+  });
+});
+
+// ─── Group 7: Provenance headers and meta tags ──────────────
+
+describe('Provenance headers and meta tags', () => {
+  it('should include attestation meta tags in HTML pages', async () => {
+    const id = uniqueId('att-meta');
+    const attestation = {
+      type: 'verify',
+      subject: { kind: 'agent', id: bob.publicKeyFingerprint },
+      context: 'Verified via DNS',
+    };
+    await app.request(`/v1/pages/${id}`, jsonSignedRequest({
+      signer: alice,
+      method: 'POST',
+      path: `/v1/pages/${id}`,
+      body: { html: '<html><head></head><body><h1>Attested</h1></body></html>', attestation },
+    }));
+
+    const readRes = await app.request(`http://localhost/p/${id}`);
+    expect(readRes.status).toBe(200);
+    const html = await readRes.text();
+    expect(html).toContain('cap:attestation-type');
+    expect(html).toContain('content="verify"');
+    expect(html).toContain('cap:attestation-subject-kind');
+    expect(html).toContain('content="agent"');
+    expect(html).toContain('cap:attestation-subject-id');
+    expect(html).toContain(bob.publicKeyFingerprint);
+  });
+
+  it('should include attestation in JSON metadata response', async () => {
+    const id = uniqueId('att-json');
+    const attestation = {
+      type: 'endorse',
+      subject: { kind: 'asset', id: `${alice.keyId}/my-docs` },
+    };
+    await app.request(`/v1/pages/${id}`, jsonSignedRequest({
+      signer: bob,
+      method: 'POST',
+      path: `/v1/pages/${id}`,
+      body: { html: '<h1>Endorsed</h1>', attestation },
+    }));
+
+    const readRes = await app.request(`http://localhost/p/${id}`, {
+      headers: { Accept: 'application/json' },
+    });
+    expect(readRes.status).toBe(200);
+    const data = await readRes.json() as any;
+    expect(data.attestation).toBeDefined();
+    expect(data.attestation.type).toBe('endorse');
+  });
+
+  it('should include CAP and X-Zenbin attestation headers in HTTP response', async () => {
+    const id = uniqueId('att-headers');
+    const attestation = {
+      type: 'review',
+      subject: { kind: 'asset', id: `${carol.keyId}/analysis` },
+    };
+    await app.request(`/v1/pages/${id}`, jsonSignedRequest({
+      signer: alice,
+      method: 'POST',
+      path: `/v1/pages/${id}`,
+      body: { html: '<h1>Reviewed</h1>', attestation },
+    }));
+
+    const readRes = await app.request(`http://localhost/p/${id}`);
+    expect(readRes.status).toBe(200);
+    expect(readRes.headers.get('CAP-Attestation-Type')).toBe('review');
+    expect(readRes.headers.get('CAP-Attestation-Subject-Kind')).toBe('asset');
+    expect(readRes.headers.get('X-Zenbin-Attestation-Type')).toBe('review');
+    expect(readRes.headers.get('X-Zenbin-Attestation-Subject-Kind')).toBe('asset');
+  });
+
+  it('should not include attestation headers for pages without attestation', async () => {
+    const id = uniqueId('att-no-att');
+    await app.request(`/v1/pages/${id}`, jsonSignedRequest({
+      signer: alice,
+      method: 'POST',
+      path: `/v1/pages/${id}`,
+      body: { html: '<h1>No Attestation</h1>' },
+    }));
+
+    const readRes = await app.request(`http://localhost/p/${id}`);
+    expect(readRes.status).toBe(200);
+    expect(readRes.headers.get('CAP-Attestation-Type')).toBeNull();
+    expect(readRes.headers.get('X-Zenbin-Attestation-Type')).toBeNull();
+  });
+});
+
+// ─── Group 8: Round-trip ───────────────────────────────────
+
+describe('Round-trip', () => {
+  it('should publish → query → read with full attestation verification', async () => {
+    const id = uniqueId('att-roundtrip');
+    const attestation = {
+      type: 'verify',
+      subject: { kind: 'agent', id: bob.publicKeyFingerprint },
+      context: 'Round-trip test',
+      metadata: { method: 'dns-txt', domain: 'example.com' },
+      timestamp: '2026-06-05T09:00:00Z',
+    };
+
+    // 1. Publish
+    const publishRes = await app.request(`/v1/pages/${id}`, jsonSignedRequest({
+      signer: alice,
+      method: 'POST',
+      path: `/v1/pages/${id}`,
+      body: { html: '<h1>Round Trip</h1>', attestation },
+    }));
+    expect(publishRes.status).toBe(201);
+    const publishData = await publishRes.json() as any;
+    expect(publishData.attestation).toBeDefined();
+    expect(publishData.attestation.type).toBe('verify');
+
+    // 2. Query
+    const queryRes = await app.request(signedGet(alice, `/v1/pages?attestation.subject=${bob.publicKeyFingerprint}`));
+    expect(queryRes.status).toBe(200);
+    const queryData = await queryRes.json() as any;
+    const found = queryData.pages.find((p: any) => p.id === id);
+    expect(found).toBeDefined();
+    expect(found.attestation.type).toBe('verify');
+    expect(found.attestation.subject.id).toBe(bob.publicKeyFingerprint);
+    expect(found.attestation.context).toBe('Round-trip test');
+    expect(found.attestation.metadata).toEqual({ method: 'dns-txt', domain: 'example.com' });
+
+    // 3. Read (JSON)
+    const readRes = await app.request(`http://localhost/p/${id}`, {
+      headers: { Accept: 'application/json' },
+    });
+    expect(readRes.status).toBe(200);
+    const readData = await readRes.json() as any;
+    expect(readData.attestation).toBeDefined();
+    expect(readData.attestation.type).toBe('verify');
+
+    // 4. Read (HTML - check headers)
+    const htmlRes = await app.request(`http://localhost/p/${id}`);
+    expect(htmlRes.headers.get('CAP-Attestation-Type')).toBe('verify');
+    expect(htmlRes.headers.get('CAP-Attestation-Subject-Id')).toBe(bob.publicKeyFingerprint);
+  });
+});
+
+// ─── Group 9: Backfill migration ────────────────────────────
+
+describe('Backfill migration', () => {
+  it('should index existing pages and be idempotent', () => {
+    const result = backfillAttestationIndexes();
+    // Running on an empty/fresh db should work fine
+    expect(result).toHaveProperty('indexed');
+    expect(result).toHaveProperty('skipped');
+
+    // Running again should be idempotent (no new indexes)
+    const result2 = backfillAttestationIndexes();
+    expect(result2.indexed).toBe(0);
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,32 @@
  * Services, routes, and storage all import from here.
  */
 
+// ─── Attestation ───────────────────────────────────────────
+
+export interface Attestation {
+  /** What kind of claim this is */
+  type: string;
+
+  /** What the claim is about */
+  subject: {
+    /** "agent" or "asset" */
+    kind: 'agent' | 'asset';
+
+    /** For agent: SHA-256 fingerprint of the subject's Ed25519 public key (43-char base64url)
+     *  For asset: signed page reference — {ownerKeyId}/{pageId} */
+    id: string;
+  };
+
+  /** Optional: human-readable context about this claim */
+  context?: string;
+
+  /** Optional: structured metadata (type-specific) */
+  metadata?: Record<string, unknown>;
+
+  /** Optional: timestamp when the attestation was made (defaults to CAP-Timestamp) */
+  timestamp?: string;
+}
+
 // ─── Stored JWK ───────────────────────────────────────────
 
 type StoredJwk = Record<string, string | boolean | undefined>;
@@ -66,6 +92,7 @@ export interface Page {
   publishMethod?: string;
   publishPath?: string;
   recipientKeyId?: string;
+  attestation?: Attestation;
   status?: 'active' | 'removed';
 }
 

--- a/src/utils/provenance.ts
+++ b/src/utils/provenance.ts
@@ -1,12 +1,13 @@
 import type { Context } from 'hono';
 import type { Page } from '../storage/db.js';
+import type { Attestation } from '../types.js';
 
 /**
  * Inject CAP Protocol provenance meta tags into HTML.
  * Adds <meta> tags for key-id, signature, digest, version, and recipient.
  */
 export function injectProvenanceMeta(html: string, page: Page): string {
-  if (!page.ownerKeyId && !page.publishSignature && !page.recipientKeyId) {
+  if (!page.ownerKeyId && !page.publishSignature && !page.recipientKeyId && !page.attestation) {
     return html;
   }
 
@@ -27,6 +28,13 @@ export function injectProvenanceMeta(html: string, page: Page): string {
   }
   if (page.recipientKeyId) {
     metaTags.push(`  <meta name="cap:recipient-key-id" content="${page.recipientKeyId}">`);
+  }
+
+  // Attestation meta tags
+  if (page.attestation) {
+    metaTags.push(`  <meta name="cap:attestation-type" content="${page.attestation.type}">`);
+    metaTags.push(`  <meta name="cap:attestation-subject-kind" content="${page.attestation.subject.kind}">`);
+    metaTags.push(`  <meta name="cap:attestation-subject-id" content="${page.attestation.subject.id}">`);
   }
 
   const provenanceBlock = metaTags.join('\n');
@@ -76,5 +84,16 @@ export function injectProvenanceHttpHeaders(c: Context, page: Page): void {
   if (page.recipientKeyId) {
     c.header('CAP-Recipient-Key-Id', page.recipientKeyId);
     c.header('X-Zenbin-Recipient-Key-Id', page.recipientKeyId);
+  }
+
+  // Attestation headers
+  if (page.attestation) {
+    c.header('CAP-Attestation-Type', page.attestation.type);
+    c.header('CAP-Attestation-Subject-Kind', page.attestation.subject.kind);
+    c.header('CAP-Attestation-Subject-Id', page.attestation.subject.id);
+    // Legacy X-Zenbin aliases
+    c.header('X-Zenbin-Attestation-Type', page.attestation.type);
+    c.header('X-Zenbin-Attestation-Subject-Kind', page.attestation.subject.kind);
+    c.header('X-Zenbin-Attestation-Subject-Id', page.attestation.subject.id);
   }
 }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,4 +1,6 @@
 import { config, ID_PATTERN } from '../config.js';
+import type { Attestation } from '../types.js';
+import { isValidFingerprint } from './fingerprint.js';
 
 export interface ValidationError {
   field: string;
@@ -314,6 +316,112 @@ const BLOCKED_HEADER_NAMES = new Set([
   'trailer',
   'authorization', // Already handled by bearer/basic auth types
 ]);
+
+/**
+ * Validate a signed page reference (asset subject ID).
+ * Format: {ownerKeyId}/{pageId}
+ * - Must contain exactly one slash
+ * - Both segments must be non-empty
+ * - Segments must match [a-zA-Z0-9_.-]+
+ */
+export function isValidSignedPageRef(ref: string): boolean {
+  const parts = ref.split('/');
+  if (parts.length !== 2) return false;
+  const [ownerKeyId, pageId] = parts;
+  if (!ownerKeyId || !pageId) return false;
+  const segmentPattern = /^[a-zA-Z0-9_.-]+$/;
+  return segmentPattern.test(ownerKeyId) && segmentPattern.test(pageId);
+}
+
+/**
+ * Validate an attestation object.
+ * Returns null if valid, or a ValidationError if invalid.
+ */
+export function validateAttestation(attestation: unknown): ValidationError | null {
+  if (!attestation || typeof attestation !== 'object') {
+    return { field: 'attestation', message: 'attestation must be an object' };
+  }
+
+  const att = attestation as Record<string, unknown>;
+
+  // type is required
+  if (!att.type || typeof att.type !== 'string') {
+    return { field: 'attestation.type', message: 'attestation type is required and must be a string' };
+  }
+
+  // subject is required
+  if (!att.subject || typeof att.subject !== 'object') {
+    return { field: 'attestation.subject', message: 'attestation subject is required and must be an object' };
+  }
+
+  const subject = att.subject as Record<string, unknown>;
+
+  // subject.kind must be "agent" or "asset"
+  if (subject.kind !== 'agent' && subject.kind !== 'asset') {
+    return { field: 'attestation.subject.kind', message: 'attestation subject kind must be "agent" or "asset"' };
+  }
+
+  // subject.id is required
+  if (typeof subject.id !== 'string' || !subject.id) {
+    return { field: 'attestation.subject.id', message: 'attestation subject id is required and must be a string' };
+  }
+
+  // Validate subject.id based on kind
+  if (subject.kind === 'agent') {
+    // Agent subject: must be a 43-char base64url SHA-256 fingerprint
+    if (!isValidFingerprint(subject.id)) {
+      return { field: 'attestation.subject.id', message: 'agent subject id must be a 43-character base64url public key fingerprint (SHA-256 of Ed25519 public key)' };
+    }
+  } else {
+    // Asset subject: must be a valid signed page reference {ownerKeyId}/{pageId}
+    if (!isValidSignedPageRef(subject.id)) {
+      return { field: 'attestation.subject.id', message: 'asset subject id must be a valid signed page reference (ownerKeyId/pageId)' };
+    }
+  }
+
+  // context is optional, max 500 chars
+  if (att.context !== undefined) {
+    if (typeof att.context !== 'string') {
+      return { field: 'attestation.context', message: 'attestation context must be a string' };
+    }
+    if (att.context.length > 500) {
+      return { field: 'attestation.context', message: 'attestation context must be 500 characters or less' };
+    }
+  }
+
+  // metadata is optional, max 2KB, flat values only
+  if (att.metadata !== undefined) {
+    if (typeof att.metadata !== 'object' || att.metadata === null) {
+      return { field: 'attestation.metadata', message: 'attestation metadata must be an object' };
+    }
+    const metadataJson = JSON.stringify(att.metadata);
+    if (metadataJson.length > 2048) {
+      return { field: 'attestation.metadata', message: 'attestation metadata must be 2KB or less' };
+    }
+    // Check for nested values
+    for (const [key, value] of Object.entries(att.metadata as Record<string, unknown>)) {
+      if (typeof key !== 'string') {
+        return { field: 'attestation.metadata', message: 'attestation metadata keys must be strings' };
+      }
+      if (typeof value !== 'string' && typeof value !== 'number' && typeof value !== 'boolean') {
+        return { field: 'attestation.metadata', message: 'attestation metadata values must be strings, numbers, or booleans (no nested objects or arrays)' };
+      }
+    }
+  }
+
+  // timestamp is optional, must be valid ISO-8601
+  if (att.timestamp !== undefined) {
+    if (typeof att.timestamp !== 'string') {
+      return { field: 'attestation.timestamp', message: 'attestation timestamp must be a string' };
+    }
+    const parsed = Date.parse(att.timestamp);
+    if (isNaN(parsed)) {
+      return { field: 'attestation.timestamp', message: 'attestation timestamp must be a valid ISO-8601 date string' };
+    }
+  }
+
+  return null;
+}
 
 /**
  * Validate a proxy request body


### PR DESCRIPTION
## CAP Attestation v0.3

Adds attestation support to ZenBin — signed claims about agents or assets, stored as an optional field on pages. Zero new endpoints; extends existing publish/list/read flows.

### Spec
https://zed.zenbin.org/cap-attestation-v0.3

### Implementation Plan
https://zed.zenbin.org/cap-attestation-v0.3-plan

### What Shipped (8 Phases)

**Phase 0: Types & Validation**
- `Attestation` interface in `src/types.ts`
- `validateAttestation()` with full validation
- `isValidSignedPageRef()` for `{ownerKeyId}/{pageId}` format

**Phase 1: Storage & Indexes**
- Two new LMDB databases: `page:attestation-subject`, `page:attestation-type-subject`
- Index add/remove on create/update/delete
- Query functions with cursor pagination + `since` filter
- `backfillAttestationIndexes()` for startup migration

**Phase 2: Service Layer**
- `IPageService.save()` accepts `attestation` (null removes, undefined preserves)

**Phase 3: Publish Route**
- `attestation` field in JSON body
- `CAP-Attestation` header (base64url JSON)
- `X-Zenbin-Attestation` legacy header
- Header priority over body
- `null` removes attestation, invalid → 400

**Phase 4: Query Route**
- `GET /v1/pages?attestation.subject={id}`
- `GET /v1/pages?attestation.type={type}&attestation.subject={id}`
- Type-only query → 400

**Phase 5 & 6: Provenance & Response**
- HTML meta tags: `cap:attestation-type`, `cap:attestation-subject-kind`, `cap:attestation-subject-id`
- HTTP headers: `CAP-Attestation-*` and `X-Zenbin-Attestation-*`
- JSON metadata includes `attestation`

**Phase 7: Init & Migration**
- `backfillAttestationIndexes()` runs on startup

**Phase 8: Tests**
- 40 new tests, 9 groups, 783 lines
- All 405 tests passing

### Key Design Decisions
- One attestation per agent per subject
- Asset subjects: signed page refs (`{ownerKeyId}/{pageId}`)
- Agent subjects: SHA-256 fingerprints
- No type registry — convention-only
- 2KB metadata limit
- Attestation chaining works naturally