### PR TITLE
Security & correctness fixes from code review

### DIFF
--- a/examples/deno_publish.ts
+++ b/examples/deno_publish.ts
@@ -31,6 +31,8 @@ const bodyHash = new Uint8Array(await crypto.subtle.digest('SHA-256', encoder.en
 const contentDigest = 'sha-256=:' + toBase64(bodyHash) + ':';
 const timestamp = new Date().toISOString();
 const nonce = crypto.randomUUID().replace(/-/g, '');
+// `path` is the full request target: pathname + query string. Publishing has no
+// query, but signed GET listing requests must include the query string here.
 const canonical = ['POST', path, timestamp, nonce, contentDigest].join('\n');
 const signatureBytes = new Uint8Array(await crypto.subtle.sign('Ed25519', privateKey, encoder.encode(canonical)));
 

--- a/examples/node-publish.mjs
+++ b/examples/node-publish.mjs
@@ -21,6 +21,8 @@ const body = JSON.stringify({
 const timestamp = new Date().toISOString();
 const nonce = crypto.randomUUID().replace(/-/g, '');
 const contentDigest = 'sha-256=:' + createHash('sha256').update(body).digest('base64') + ':';
+// `path` is the full request target: pathname + query string. Publishing has no
+// query, but signed GET listing requests must include the query string here.
 const canonical = ['POST', path, timestamp, nonce, contentDigest].join('\n');
 const signature = signBytes(null, Buffer.from(canonical), privateKey)
   .toString('base64')

--- a/examples/python_publish.py
+++ b/examples/python_publish.py
@@ -27,6 +27,8 @@ body = json.dumps(body_obj, separators=(',', ':'))
 timestamp = datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
 nonce = uuid.uuid4().hex
 content_digest = 'sha-256=:' + base64.b64encode(hashlib.sha256(body.encode()).digest()).decode() + ':'
+# `path` is the full request target: pathname + query string. Publishing has no
+# query, but signed GET listing requests must include the query string here.
 canonical = '\n'.join(['POST', path, timestamp, nonce, content_digest])
 signature = base64.urlsafe_b64encode(private_key.sign(canonical.encode())).decode().rstrip('=')
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "jsonwebtoken": "^9.0.2",
         "lmdb": "^3.1.5",
         "posthog-node": "^5.26.0",
-        "stripe": "^22.1.1"
+        "stripe": "^22.1.1",
+        "undici": "^6.26.0"
       },
       "devDependencies": {
         "@types/bcryptjs": "^3.0.0",
@@ -1895,6 +1896,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "jsonwebtoken": "^9.0.2",
     "lmdb": "^3.1.5",
     "posthog-node": "^5.26.0",
-    "stripe": "^22.1.1"
+    "stripe": "^22.1.1",
+    "undici": "^6.26.0"
   },
   "devDependencies": {
     "@types/bcryptjs": "^3.0.0",

--- a/skills/zenbin-brain/scripts/signed-get.js
+++ b/skills/zenbin-brain/scripts/signed-get.js
@@ -39,12 +39,14 @@ function loadKeys(keyfile) {
   return JSON.parse(fs.readFileSync(keyfile, 'utf8'));
 }
 
-function signGet(urlPath, keys) {
+// `target` must be the full request target: pathname + query string. The
+// server signs path+query, so query parameters must be included here too.
+function signGet(target, keys) {
   const timestamp = new Date().toISOString();
   const nonce = `${Date.now()}-${crypto.randomBytes(8).toString('hex')}`;
   const digest = crypto.createHash('sha256').update('').digest('base64');
   const contentDigest = `sha-256=:${digest}:`;
-  const canonical = ['GET', urlPath, timestamp, nonce, contentDigest].join('\n');
+  const canonical = ['GET', target, timestamp, nonce, contentDigest].join('\n');
   const privateKey = crypto.createPrivateKey({ key: keys.privateJwk, format: 'jwk' });
   const signature = crypto.sign(null, Buffer.from(canonical, 'utf8'), privateKey);
   return {
@@ -127,7 +129,7 @@ async function main() {
 
   if (args.verify) {
     const unsigned = await get(url.toString());
-    const signed = await get(url.toString(), signGet(url.pathname, keys));
+    const signed = await get(url.toString(), signGet(url.pathname + url.search, keys));
     const ok = unsigned.status === 401 && signed.status === 200;
     const result = {
       ok,
@@ -144,7 +146,7 @@ async function main() {
     process.exit(ok ? 0 : 1);
   }
 
-  const res = await get(url.toString(), signGet(url.pathname, keys));
+  const res = await get(url.toString(), signGet(url.pathname + url.search, keys));
   if (args.json) {
     emitJson({ status: res.status, url: url.toString(), headers: res.headers, body: res.body, hint: authHint(res.status) });
     process.exit(res.status === 200 ? 0 : 1);

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,6 +16,13 @@ export const config = {
   get maxPayloadSize() { return parseInt(process.env.MAX_PAYLOAD_SIZE || '2097152', 10); },
   get maxImageSize() { return parseInt(process.env.MAX_IMAGE_SIZE || '5242880', 10); },
   get maxIdLength() { return parseInt(process.env.MAX_ID_LENGTH || '128', 10); },
+  // Hard transport-level cap on request body size (bytes). Generous enough for a
+  // base64-encoded max-size video upload (~50MB → ~67MB) plus JSON overhead;
+  // per-route validation still enforces the real per-field limits.
+  get maxRequestBodyBytes() { return parseInt(process.env.MAX_REQUEST_BODY_BYTES || '78643200', 10); },
+
+  // Trust X-Forwarded-For / X-Real-IP headers only when behind a trusted proxy.
+  get trustProxy() { return process.env.TRUST_PROXY === 'true'; },
 
   // Media settings
   allowedImageTypes: [

--- a/src/docs/agentInstructions.ts
+++ b/src/docs/agentInstructions.ts
@@ -341,6 +341,10 @@ GET /v1/pages
 
 Requires a signed request. Returns all pages owned by the authenticated key, with cursor-based pagination.
 
+> **Signing note:** the canonical \`path\` you sign must include the query string
+> exactly as sent (e.g. \`/v1/pages?recipient=me&limit=20\`). The server signs
+> path + query, so omitting the query will fail signature verification.
+
 **Query parameters:**
 
 | Parameter | Type | Default | Max | Description |

--- a/src/docs/agentSetupInstructions.ts
+++ b/src/docs/agentSetupInstructions.ts
@@ -104,6 +104,11 @@ sha-256=:BASE64_DIGEST:
 
 Fields in order: method, path, timestamp, nonce, content-digest — joined by newlines.
 
+The \`path\` is the full request target — pathname **plus query string**. For
+publishing (\`POST /v1/pages/...\`) there is no query, so it is just the pathname.
+For signed GET listing endpoints, include the query string exactly as sent
+(e.g. \`/v1/pages?cursor=abc&limit=20\`), or the signature will not verify.
+
 ### Sign the canonical string
 
 \`\`\`js

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,10 @@ import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { logger } from 'hono/logger';
+import { bodyLimit } from 'hono/body-limit';
 import dotenv from 'dotenv';
 import { config } from './config.js';
-import { initDatabase, closeDatabase, backfillOwnerIndex, backfillRecipientIndex, backfillKeyFingerprints, backfillAttestationIndexes } from './storage/db.js';
+import { initDatabase, closeDatabase, backfillOwnerIndex, backfillRecipientIndex, backfillKeyFingerprints, backfillAttestationIndexes, cleanupExpiredNonces } from './storage/db.js';
 import { initVideoStorage } from './storage/video.js';
 import { createServices, type Services } from './services/container.js';
 import { pages } from './routes/pages.js';
@@ -39,6 +40,12 @@ const services = createServices();
 // Middleware
 app.use('*', logger());
 app.use('*', cors());
+// Hard transport-level body cap: reject oversized payloads before any handler
+// buffers the full body (e.g. signed-agent digest verification reads it whole).
+app.use('*', bodyLimit({
+  maxSize: config.maxRequestBodyBytes,
+  onError: (c) => c.json({ error: 'Request body too large' }, 413),
+}));
 app.use('*', rateLimit);
 
 // Inject services into request context
@@ -49,19 +56,26 @@ app.use('*', async (c, next) => {
 
 // Subdomain detection middleware
 app.use('*', async (c, next) => {
-  const host = c.req.header('host') || '';
-  const baseDomain = config.subdomains.baseDomain;
-  
-  // Check if this is a subdomain request
-  const parts = host.split('.');
-  if (parts.length >= 3) {
-    const potentialSubdomain = parts[0].toLowerCase();
-    const reserved = new Set(config.subdomains.reservedNames);
-    if (!reserved.has(potentialSubdomain) && potentialSubdomain !== 'www') {
-      c.set('subdomain', potentialSubdomain);
+  // Strip any port, then require the host to actually be under our base domain
+  // before treating the first label as a subdomain. Without this, any host with
+  // ≥3 labels (e.g. a spoofed Host header or foo.attacker.com pointed here) is
+  // routed as a subdomain.
+  const host = (c.req.header('host') || '').split(':')[0].toLowerCase();
+  const baseDomain = config.subdomains.baseDomain.toLowerCase();
+  const suffix = `.${baseDomain}`;
+
+  if (host.endsWith(suffix)) {
+    const labels = host.slice(0, -suffix.length).split('.');
+    // Exactly one label in front of the base domain → a subdomain.
+    if (labels.length === 1 && labels[0]) {
+      const potentialSubdomain = labels[0];
+      const reserved = new Set(config.subdomains.reservedNames);
+      if (!reserved.has(potentialSubdomain) && potentialSubdomain !== 'www') {
+        c.set('subdomain', potentialSubdomain);
+      }
     }
   }
-  
+
   await next();
 });
 
@@ -239,6 +253,18 @@ async function main() {
 
     console.log('Initializing analytics...');
     initAnalytics();
+
+    // Periodically sweep expired nonces so the nonce store does not grow
+    // without bound (honest clients never re-present a nonce, so the inline
+    // cleanup never fires for them).
+    const nonceSweep = setInterval(() => {
+      try {
+        cleanupExpiredNonces();
+      } catch (err) {
+        console.error('Nonce sweep failed:', err);
+      }
+    }, 10 * 60 * 1000);
+    nonceSweep.unref();
 
     // Security warnings for missing secrets
     if (!process.env.ZENBIN_JWT_SECRET) {

--- a/src/middleware/adminAuth.ts
+++ b/src/middleware/adminAuth.ts
@@ -1,10 +1,21 @@
 import { Context, Next } from 'hono';
+import crypto from 'node:crypto';
 import { config } from '../config.js';
 
-export async function requireAdmin(c: Context, next: Next) {
-  const token = c.req.header('X-Admin-Token') || c.req.header('Authorization')?.replace(/^Bearer\s+/i, '');
+/** Constant-time string compare via fixed-length SHA-256 digests. */
+function safeEqual(a: string, b: string): boolean {
+  const ah = crypto.createHash('sha256').update(a).digest();
+  const bh = crypto.createHash('sha256').update(b).digest();
+  return crypto.timingSafeEqual(ah, bh);
+}
 
-  if (!token || token !== config.admin.token) {
+export async function requireAdmin(c: Context, next: Next) {
+  const token = c.req.header('X-Admin-Token') || c.req.header('Authorization')?.replace(/^Bearer\s+/i, '') || '';
+  const expected = config.admin.token;
+
+  // Fail closed when no admin token is configured; otherwise compare in
+  // constant time so the long-lived admin secret is not leaked via timing.
+  if (!expected || !token || !safeEqual(token, expected)) {
     return c.json({ error: 'Admin authentication required' }, 401);
   }
 

--- a/src/middleware/proxyRateLimit.ts
+++ b/src/middleware/proxyRateLimit.ts
@@ -1,10 +1,14 @@
 import { Context, Next } from 'hono';
+import { getConnInfo } from '@hono/node-server/conninfo';
 import { config } from '../config.js';
 
 interface RateLimitEntry {
   count: number;
   resetAt: number;
 }
+
+// Hard cap on distinct tracked keys, to bound memory under identity rotation.
+const MAX_RATE_LIMIT_ENTRIES = 100_000;
 
 // Separate in-memory rate limiter for proxy endpoint
 // For production, consider using Redis or a distributed store
@@ -21,19 +25,22 @@ setInterval(() => {
 }, 60000); // Clean every minute
 
 function getClientIp(c: Context): string {
-  // Check common proxy headers
-  const forwarded = c.req.header('x-forwarded-for');
-  if (forwarded) {
-    return forwarded.split(',')[0].trim();
-  }
-  
-  const realIp = c.req.header('x-real-ip');
-  if (realIp) {
-    return realIp;
+  // Only trust proxy headers when explicitly running behind a trusted proxy.
+  if (config.trustProxy) {
+    const forwarded = c.req.header('x-forwarded-for');
+    if (forwarded) {
+      const parts = forwarded.split(',').map((s) => s.trim()).filter(Boolean);
+      if (parts.length > 0) return parts[parts.length - 1];
+    }
+    const realIp = c.req.header('x-real-ip');
+    if (realIp) return realIp;
   }
 
-  // Fallback to a default (in production, you'd want the actual IP)
-  return 'unknown';
+  try {
+    return getConnInfo(c).remote.address || 'unknown';
+  } catch {
+    return 'unknown';
+  }
 }
 
 export async function proxyRateLimit(c: Context, next: Next) {
@@ -51,6 +58,11 @@ export async function proxyRateLimit(c: Context, next: Next) {
       count: 1,
       resetAt: now + windowMs,
     };
+    if (proxyRateLimitStore.size >= MAX_RATE_LIMIT_ENTRIES) {
+      for (const [k, e] of proxyRateLimitStore.entries()) {
+        if (e.resetAt < now) proxyRateLimitStore.delete(k);
+      }
+    }
     proxyRateLimitStore.set(key, entry);
   } else {
     entry.count++;

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -1,10 +1,15 @@
 import { Context, Next } from 'hono';
+import { getConnInfo } from '@hono/node-server/conninfo';
 import { config } from '../config.js';
 
 interface RateLimitEntry {
   count: number;
   resetAt: number;
 }
+
+// Hard cap on distinct tracked keys, to bound memory if an attacker rotates
+// identities faster than the cleanup interval.
+const MAX_RATE_LIMIT_ENTRIES = 100_000;
 
 // Simple in-memory rate limiter
 // For production, consider using Redis or a distributed store
@@ -21,19 +26,25 @@ setInterval(() => {
 }, 60000); // Clean every minute
 
 function getClientIp(c: Context): string {
-  // Check common proxy headers
-  const forwarded = c.req.header('x-forwarded-for');
-  if (forwarded) {
-    return forwarded.split(',')[0].trim();
-  }
-  
-  const realIp = c.req.header('x-real-ip');
-  if (realIp) {
-    return realIp;
+  // Only trust proxy headers when explicitly running behind a trusted proxy —
+  // otherwise X-Forwarded-For is client-spoofable and defeats the limiter.
+  if (config.trustProxy) {
+    const forwarded = c.req.header('x-forwarded-for');
+    if (forwarded) {
+      const parts = forwarded.split(',').map((s) => s.trim()).filter(Boolean);
+      // Rightmost hop is the one added by our trusted proxy.
+      if (parts.length > 0) return parts[parts.length - 1];
+    }
+    const realIp = c.req.header('x-real-ip');
+    if (realIp) return realIp;
   }
 
-  // Fallback to a default (in production, you'd want the actual IP)
-  return 'unknown';
+  // Fall back to the real socket address.
+  try {
+    return getConnInfo(c).remote.address || 'unknown';
+  } catch {
+    return 'unknown';
+  }
 }
 
 export async function rateLimit(c: Context, next: Next) {
@@ -50,6 +61,12 @@ export async function rateLimit(c: Context, next: Next) {
       count: 1,
       resetAt: now + windowMs,
     };
+    // Bound memory: if the store is saturated, evict expired entries first.
+    if (rateLimitStore.size >= MAX_RATE_LIMIT_ENTRIES) {
+      for (const [k, e] of rateLimitStore.entries()) {
+        if (e.resetAt < now) rateLimitStore.delete(k);
+      }
+    }
     rateLimitStore.set(ip, entry);
   } else {
     entry.count++;

--- a/src/middleware/signedAgent.ts
+++ b/src/middleware/signedAgent.ts
@@ -54,6 +54,16 @@ function isWriteMethod(method: string): boolean {
   return method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'DELETE';
 }
 
+/**
+ * The signed request target: path + query string. The query string is included
+ * so a man-in-the-middle cannot alter query parameters (cursor, limit, filters,
+ * tokens) on a signed request without invalidating the signature.
+ */
+function requestTarget(c: Context): string {
+  const url = new URL(c.req.url);
+  return `${url.pathname}${url.search}`;
+}
+
 function hasAllHeaders(headers: OptionalSignedHeaders): headers is RequiredSignedHeaders {
   return Boolean(
     headers.keyId
@@ -143,9 +153,10 @@ export async function verifySignedAgent(c: Context): Promise<SignedAgentContext 
     return reject(c, 401, 'Content digest mismatch', headers.keyId, undefined, ErrorCodes.CONTENT_DIGEST_MISMATCH);
   }
 
+  const target = requestTarget(c);
   const canonical = buildCanonicalRequest({
     method: c.req.method,
-    path: c.req.path,
+    path: target,
     timestamp: headers.timestamp,
     nonce: headers.nonce,
     contentDigest: headers.contentDigest,
@@ -179,7 +190,7 @@ export async function verifySignedAgent(c: Context): Promise<SignedAgentContext 
     timestamp: headers.timestamp,
     nonce: headers.nonce,
     method: c.req.method,
-    path: c.req.path,
+    path: target,
   });
 
   return c.get('signedAgent')!;

--- a/src/middleware/verifyApiKey.ts
+++ b/src/middleware/verifyApiKey.ts
@@ -2,6 +2,7 @@
 // Verifies API keys from the ZenBin Portal
 
 import { Context, Next } from 'hono';
+import { getConnInfo } from '@hono/node-server/conninfo';
 import jwt from 'jsonwebtoken';
 import { config } from '../config.js';
 
@@ -46,7 +47,7 @@ export async function verifyApiKey(c: Context, next: Next) {
   }
 
   try {
-    const decoded = jwt.verify(token, ZENBIN_JWT_SECRET) as JwtPayload;
+    const decoded = jwt.verify(token, ZENBIN_JWT_SECRET, { algorithms: ['HS256'] }) as JwtPayload;
     
     // Attach user info to context
     c.set('user', { ...decoded, plan: decoded.plan });
@@ -91,8 +92,25 @@ async function handleFreeTier(c: Context, next: Next) {
 }
 
 function getClientId(c: Context): string {
-  // Use IP + user agent as client identifier for free tier
-  const ip = c.req.header('X-Forwarded-For') || c.req.header('X-Real-IP') || 'unknown';
+  // Derive the client IP from the real socket unless explicitly behind a
+  // trusted proxy. Client-supplied X-Forwarded-For is spoofable and would let
+  // a caller reset the free-tier counter by rotating the header.
+  let ip = 'unknown';
+  if (config.trustProxy) {
+    const forwarded = c.req.header('X-Forwarded-For');
+    if (forwarded) {
+      const parts = forwarded.split(',').map((s) => s.trim()).filter(Boolean);
+      if (parts.length > 0) ip = parts[parts.length - 1];
+    } else {
+      ip = c.req.header('X-Real-IP') || 'unknown';
+    }
+  } else {
+    try {
+      ip = getConnInfo(c).remote.address || 'unknown';
+    } catch {
+      ip = 'unknown';
+    }
+  }
   const ua = c.req.header('User-Agent') || 'unknown';
   return `${ip}:${ua.slice(0, 50)}`;
 }

--- a/src/routes/adminKeys.ts
+++ b/src/routes/adminKeys.ts
@@ -1,6 +1,8 @@
 import { Hono } from 'hono';
 import { ErrorCodes, errorResponse } from '../errors.js';
 import { requireAdmin } from '../middleware/adminAuth.js';
+import { validateEd25519PublicJwk } from '../utils/httpSignature.js';
+import { computeFingerprint } from '../utils/fingerprint.js';
 import type { Services } from '../services/container.js';
 
 const adminKeys = new Hono();
@@ -42,15 +44,34 @@ adminKeys.post('/', async (c) => {
     return errorResponse(ErrorCodes.INVALID_REQUEST, 'publicJwk is required', 400);
   }
 
+  const trimmedKeyId = body.keyId.trim();
+  if (!trimmedKeyId) {
+    return errorResponse(ErrorCodes.INVALID_REQUEST, 'keyId is required', 400);
+  }
+  if (trimmedKeyId.length > 128) {
+    return errorResponse(ErrorCodes.PAGE_INVALID_ID, 'keyId must be 128 characters or less', 400);
+  }
+  if (!/^[A-Za-z0-9._:-]+$/.test(trimmedKeyId)) {
+    return errorResponse(ErrorCodes.INVALID_REQUEST, 'keyId may only contain letters, numbers, dots, underscores, colons, and hyphens', 400);
+  }
+
+  // Validate the JWK the same way self-service registration does, so an
+  // admin-registered key has a usable key and a fingerprint (required to
+  // receive directed pages and to verify signatures).
+  if (!validateEd25519PublicJwk(body.publicJwk)) {
+    return errorResponse(ErrorCodes.INVALID_REQUEST, 'publicJwk must be a valid Ed25519 public JWK', 400);
+  }
+
   const services = getServices(c);
-  const existing = services.keys.get(body.keyId);
+  const existing = services.keys.get(trimmedKeyId);
   if (existing) {
-    return errorResponse(ErrorCodes.KEY_ALREADY_EXISTS, `Signing key '${body.keyId}' already exists`, 409);
+    return errorResponse(ErrorCodes.KEY_ALREADY_EXISTS, `Signing key '${trimmedKeyId}' already exists`, 409);
   }
 
   const key = await services.keys.save({
-    keyId: body.keyId,
+    keyId: trimmedKeyId,
     publicJwk: body.publicJwk as Record<string, string | boolean | undefined>,
+    publicKeyFingerprint: computeFingerprint(body.publicJwk as { x: string }),
     scopes: body.scopes || [],
     status: (body.status as 'active' | 'blocked' | 'revoked') || 'active',
   });

--- a/src/routes/pages.ts
+++ b/src/routes/pages.ts
@@ -381,6 +381,23 @@ pages.post('/:id', async (c) => {
     }
   }
 
+  // Atomically reserve a quota slot for a brand-new page. This closes the race
+  // between the read-only plan check above and the usage increment: the check,
+  // cycle reset, and increment all happen in one transaction.
+  let reservedQuota = false;
+  if (!existingPage) {
+    const reservation = services.pages.reservePageQuota(keyId);
+    if (!reservation.allowed) {
+      if (videoPath) await services.pages.deleteVideoFile(videoPath);
+      return c.json({
+        error: reservation.reason,
+        plan: reservation.plan,
+        upgradeUrl: `${config.baseUrl}/v1/billing/checkout?plan=pro`,
+      }, 402);
+    }
+    reservedQuota = true;
+  }
+
   const { page, created } = await services.pages.save(
     id,
     {
@@ -413,9 +430,10 @@ pages.post('/:id', async (c) => {
     services.pages.incrementSubdomainPageCount(subdomain);
   }
 
-  // Track usage for billing
-  if (created) {
-    services.pages.trackPageCreation(keyId);
+  // Usage was already reserved atomically above. If the page turned out to
+  // already exist (concurrent create), release the slot we reserved.
+  if (reservedQuota && !created) {
+    services.pages.releasePageQuota(keyId);
   }
 
   const baseUrl = config.baseUrl;

--- a/src/routes/proxy.ts
+++ b/src/routes/proxy.ts
@@ -1,7 +1,24 @@
 import { Hono } from 'hono';
+import { Agent } from 'undici';
 import { config } from '../config.js';
 import { validateProxyRequest, ProxyRequest } from '../utils/validation.js';
 import { resolveAndValidate } from '../utils/ssrf.js';
+
+/**
+ * Build an undici dispatcher that pins every connection to a pre-validated IP,
+ * so the network stack cannot re-resolve the hostname to a different (e.g.
+ * rebound, private) address after our SSRF check. The Host header / SNI is
+ * still derived from the original URL by fetch().
+ */
+function pinnedDispatcher(ip: string): Agent {
+  return new Agent({
+    connect: {
+      lookup: (_hostname, _options, callback) => {
+        callback(null, [{ address: ip, family: ip.includes(':') ? 6 : 4 }]);
+      },
+    },
+  });
+}
 
 export interface ProxyResponse {
   status: number;
@@ -73,9 +90,11 @@ proxy.post('/', async (c) => {
     }
   }
 
-  // 6. SSRF validation (resolveAndValidate)
+  // 6. SSRF validation (resolveAndValidate) — capture the validated IP so the
+  // outgoing fetch connects to exactly that address (no re-resolution).
+  let pinnedIp: string;
   try {
-    await resolveAndValidate(proxyReq.url);
+    ({ ip: pinnedIp } = await resolveAndValidate(proxyReq.url));
   } catch (err) {
     const message = err instanceof Error ? err.message : 'SSRF validation failed';
     return c.json({ error: message }, 400);
@@ -126,11 +145,13 @@ proxy.post('/', async (c) => {
 
   try {
     while (redirectCount <= maxRedirects) {
-      const fetchOptions: RequestInit = {
+      const fetchOptions: RequestInit & { dispatcher?: Agent } = {
         method: redirectCount === 0 ? method : 'GET', // Follow redirects with GET
         headers: outgoingHeaders,
         signal: controller.signal,
         redirect: 'manual',
+        // Pin the connection to the validated IP for the current URL.
+        dispatcher: pinnedDispatcher(pinnedIp),
       };
 
       // Only include body on first request and if method supports it
@@ -150,9 +171,9 @@ proxy.post('/', async (c) => {
         // Resolve relative URLs
         const redirectUrl = new URL(location, currentUrl).toString();
 
-        // Validate redirect target for SSRF
+        // Validate redirect target for SSRF and re-pin to its validated IP.
         try {
-          await resolveAndValidate(redirectUrl);
+          ({ ip: pinnedIp } = await resolveAndValidate(redirectUrl));
         } catch (err) {
           clearTimeout(timeoutId);
           const message = err instanceof Error ? err.message : 'SSRF validation failed on redirect';

--- a/src/routes/render.ts
+++ b/src/routes/render.ts
@@ -392,14 +392,18 @@ render.get('/:id/raw', async (c) => {
     return authResponse;
   }
 
+  // Distinct ETag for the raw representation so a shared cache can't return a
+  // 304 with raw bytes for an If-None-Match captured from the rendered HTML
+  // view (which carries injected provenance/analytics and a different type).
+  const rawEtag = generateEtag(`${page.etag}:raw`);
   const ifNoneMatch = c.req.header('If-None-Match');
-  if (etagMatches(ifNoneMatch, page.etag)) {
+  if (etagMatches(ifNoneMatch, rawEtag)) {
     return c.body(null, 304);
   }
 
   c.header('Content-Type', 'text/plain; charset=utf-8');
   c.header('Content-Disposition', `inline; filename="${id}.html"`);
-  c.header('ETag', page.etag);
+  c.header('ETag', rawEtag);
   c.header('Cache-Control', 'public, max-age=0, must-revalidate');
   trackRequestView(c, id);
   return c.body(page.html);

--- a/src/routes/subdomainRender.ts
+++ b/src/routes/subdomainRender.ts
@@ -17,6 +17,16 @@ type Variables = {
   subdomain: string;
 };
 
+/** Escape text for safe interpolation into HTML element/attribute content. */
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 const subdomainRender = new Hono<{ Variables: Variables }>();
 
 subdomainRender.use('*', async (c, next) => {
@@ -105,8 +115,23 @@ const SECURITY_HEADERS = {
   'X-Frame-Options': 'DENY',
 };
 
+/**
+ * Return an HTML error/placeholder page with the sandbox security headers
+ * applied (including CSP). These pages reflect request-derived values, so they
+ * must carry the same CSP as rendered pages.
+ */
+function htmlErrorResponse(c: Context, html: string, status: number = 200) {
+  for (const [key, value] of Object.entries(SECURITY_HEADERS)) {
+    c.header(key, value);
+  }
+  c.header('Content-Type', 'text/html; charset=utf-8');
+  return c.body(html, status as 200);
+}
+
 // Placeholder HTML for new/empty subdomains
-const getPlaceholderPage = (subdomain: string): string => `<!DOCTYPE html>
+const getPlaceholderPage = (rawSubdomain: string): string => {
+  const subdomain = escapeHtml(rawSubdomain);
+  return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
@@ -164,9 +189,13 @@ const getPlaceholderPage = (subdomain: string): string => `<!DOCTYPE html>
   </div>
 </body>
 </html>`;
+};
 
 // 404 page for subdomains
-const getNotFoundPage = (subdomain: string, path: string): string => `<!DOCTYPE html>
+const getNotFoundPage = (rawSubdomain: string, rawPath: string): string => {
+  const subdomain = escapeHtml(rawSubdomain);
+  const path = escapeHtml(rawPath);
+  return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
@@ -223,9 +252,12 @@ const getNotFoundPage = (subdomain: string, path: string): string => `<!DOCTYPE 
   </div>
 </body>
 </html>`;
+};
 
 // Non-existent subdomain page
-const getNonExistentSubdomainPage = (subdomain: string): string => `<!DOCTYPE html>
+const getNonExistentSubdomainPage = (rawSubdomain: string): string => {
+  const subdomain = escapeHtml(rawSubdomain);
+  return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
@@ -283,6 +315,7 @@ const getNonExistentSubdomainPage = (subdomain: string): string => `<!DOCTYPE ht
   </div>
 </body>
 </html>`;
+};
 
 /**
  * Verify page authentication
@@ -349,24 +382,23 @@ async function verifyPageAuth(c: Context, page: Page): Promise<Response | null> 
 
 // Middleware to extract subdomain from host header
 const extractSubdomain = async (c: Context, next: Next) => {
-  const host = c.req.header('host') || '';
-  
-  // Check if this is a subdomain request
-  // host format: subdomain.zenbin.io or just zenbin.io
-  const parts = host.split('.');
-  
-  if (parts.length >= 3) {
-    // This looks like a subdomain request: something.zenbin.io
-    const potentialSubdomain = parts[0].toLowerCase();
-    
-    // Check if it's a reserved name (should route to main site)
-    const reserved = new Set(config.subdomains.reservedNames);
-    if (!reserved.has(potentialSubdomain) && potentialSubdomain !== 'www') {
-      // This is a real subdomain request
-      c.set('subdomain', potentialSubdomain);
+  // Require the host to actually be under our base domain before treating the
+  // leading label as a subdomain (avoids Host-header confusion / domain fronting).
+  const host = (c.req.header('host') || '').split(':')[0].toLowerCase();
+  const baseDomain = config.subdomains.baseDomain.toLowerCase();
+  const suffix = `.${baseDomain}`;
+
+  if (host.endsWith(suffix)) {
+    const labels = host.slice(0, -suffix.length).split('.');
+    if (labels.length === 1 && labels[0]) {
+      const potentialSubdomain = labels[0];
+      const reserved = new Set(config.subdomains.reservedNames);
+      if (!reserved.has(potentialSubdomain) && potentialSubdomain !== 'www') {
+        c.set('subdomain', potentialSubdomain);
+      }
     }
   }
-  
+
   await next();
 };
 
@@ -397,7 +429,7 @@ subdomainRender.get('/*', async (c) => {
   const subdomainObj = getSubdomain(subdomain);
   if (!subdomainObj) {
     c.header('Content-Type', 'text/html; charset=utf-8');
-    return c.body(getNonExistentSubdomainPage(subdomain), 404);
+    return htmlErrorResponse(c, getNonExistentSubdomainPage(subdomain), 404);
   }
   
   // Get the path and detect explicit asset/source suffixes before normal page rendering.
@@ -417,7 +449,7 @@ subdomainRender.get('/*', async (c) => {
   const idError = validateId(pageId);
   if (idError) {
     c.header('Content-Type', 'text/html; charset=utf-8');
-    return c.body(getNotFoundPage(subdomain, path), 404);
+    return htmlErrorResponse(c, getNotFoundPage(subdomain, path), 404);
   }
   
   // Get the page
@@ -428,12 +460,12 @@ subdomainRender.get('/*', async (c) => {
     // Special case: if requesting root and no index page, show placeholder
     if (pageId === 'index') {
       c.header('Content-Type', 'text/html; charset=utf-8');
-      return c.body(getPlaceholderPage(subdomain));
+      return htmlErrorResponse(c, getPlaceholderPage(subdomain));
     }
     
     // Otherwise, show 404
     c.header('Content-Type', 'text/html; charset=utf-8');
-    return c.body(getNotFoundPage(subdomain, path), 404);
+    return htmlErrorResponse(c, getNotFoundPage(subdomain, path), 404);
   }
   
   // Check authentication
@@ -717,7 +749,7 @@ export async function serveSubdomainPage(c: any, subdomain: string, path: string
   const subdomainObj = getSubdomain(subdomain);
   if (!subdomainObj) {
     c.header('Content-Type', 'text/html; charset=utf-8');
-    return c.body(getNonExistentSubdomainPage(subdomain), 404);
+    return htmlErrorResponse(c, getNonExistentSubdomainPage(subdomain), 404);
   }
   
   // Detect explicit asset/source suffixes before normal page rendering.
@@ -737,7 +769,7 @@ export async function serveSubdomainPage(c: any, subdomain: string, path: string
   const idError = validateId(pageId);
   if (idError) {
     c.header('Content-Type', 'text/html; charset=utf-8');
-    return c.body(getNotFoundPage(subdomain, path), 404);
+    return htmlErrorResponse(c, getNotFoundPage(subdomain, path), 404);
   }
   
   // Get the page
@@ -748,12 +780,12 @@ export async function serveSubdomainPage(c: any, subdomain: string, path: string
     // Special case: if requesting root and no index page, show placeholder
     if (pageId === 'index') {
       c.header('Content-Type', 'text/html; charset=utf-8');
-      return c.body(getPlaceholderPage(subdomain));
+      return htmlErrorResponse(c, getPlaceholderPage(subdomain));
     }
     
     // Otherwise, show 404
     c.header('Content-Type', 'text/html; charset=utf-8');
-    return c.body(getNotFoundPage(subdomain, path), 404);
+    return htmlErrorResponse(c, getNotFoundPage(subdomain, path), 404);
   }
   
   // Check authentication

--- a/src/routes/subdomains.ts
+++ b/src/routes/subdomains.ts
@@ -64,19 +64,27 @@ subdomains.post('/:name', async (c) => {
     return errorResponse(ErrorCodes.SUBDOMAIN_TAKEN, `Subdomain '${name}' is already taken`, 409);
   }
 
-  // ─── Plan limit check ────────────────────────────────────
-  let agentKey = keyId ? await services.keys.checkAndResetCycle(keyId) : undefined;
-  const subdomainLimit = services.subdomains.checkClaimLimit(keyId || '');
-  if (!subdomainLimit.allowed) {
-    const plan = agentKey ? (agentKey.plan || 'free') : 'free';
+  // ─── Atomic plan-limit check + claim ─────────────────────
+  // The ownership-cap check and the claim write happen in one transaction so
+  // concurrent claims cannot both pass, and the cap is enforced against the
+  // number of subdomains actually owned (not a resettable monthly counter).
+  const agentKey = keyId ? await services.keys.checkAndResetCycle(keyId) : undefined;
+  const plan = agentKey ? (agentKey.plan || 'free') : 'free';
+  const claim = services.subdomains.reserveAndClaim(name, keyId, plan);
+  if (!claim.allowed) {
     return c.json({
-      error: subdomainLimit.reason,
+      error: claim.reason,
       plan,
       upgradeUrl: `${config.baseUrl}/v1/billing/checkout?plan=pro`,
     }, 402);
   }
+  if (!claim.created || !claim.subdomain) {
+    // Lost the race: the name was claimed between our check and the reserve.
+    return errorResponse(ErrorCodes.SUBDOMAIN_TAKEN, `Subdomain '${name}' is already taken`, 409);
+  }
 
-  const { subdomain, created } = await services.subdomains.save(name, keyId);
+  const subdomain = claim.subdomain;
+  const created = claim.created;
   const baseUrl = config.baseUrl.replace(/^https?:\/\//, '');
   const protocol = config.baseUrl.startsWith('https') ? 'https' : 'http';
 

--- a/src/services/billingService.ts
+++ b/src/services/billingService.ts
@@ -40,6 +40,12 @@ export class BillingService implements IBillingService {
       throw new Error(`Agent key '${keyId}' not found.`);
     }
 
+    // Prevent duplicate subscriptions / double billing. Plan changes must go
+    // through the billing portal, not a fresh checkout.
+    if (agentKey.subscriptionId) {
+      throw new Error('Key already has an active subscription. Use the billing portal to change plans.');
+    }
+
     const priceId = getPriceId(plan);
     if (!priceId) {
       throw new Error(`Invalid plan '${plan}' or price ID not configured.`);
@@ -122,23 +128,26 @@ export class BillingService implements IBillingService {
         const subscriptionId = session.subscription;
 
         if (keyId && plan) {
-          await updateAgentKeyPlan(keyId, plan, customerId, subscriptionId);
-          await resetAgentKeyUsage(keyId);
+          const existing = getAgentKey(keyId);
+          // Idempotent: only apply + reset usage on a real transition, so a
+          // redelivered webhook cannot re-zero accrued mid-cycle usage.
+          if (!existing || existing.subscriptionId !== subscriptionId || existing.plan !== plan) {
+            await updateAgentKeyPlan(keyId, plan, customerId, subscriptionId);
+            await resetAgentKeyUsage(keyId);
+          }
         }
         break;
       }
 
       case 'customer.subscription.deleted': {
         const subscription = event.data.object;
-        const customerId = typeof subscription.customer === 'string'
-          ? subscription.customer
-          : subscription.customer?.id;
         const subscriptionId = subscription.id;
 
-        const agentKey = listAgentKeys().find((key) => (
-          (subscriptionId && key.subscriptionId === subscriptionId)
-          || (customerId && key.stripeCustomerId === customerId)
-        ));
+        // Match strictly on the recorded subscription id — cancelling an old
+        // subscription must not downgrade a key that has an active replacement.
+        const agentKey = subscriptionId
+          ? listAgentKeys().find((key) => key.subscriptionId === subscriptionId)
+          : undefined;
 
         if (agentKey) {
           await updateAgentKeyPlan(agentKey.keyId, 'free', agentKey.stripeCustomerId, '');

--- a/src/services/interfaces.ts
+++ b/src/services/interfaces.ts
@@ -55,6 +55,8 @@ export interface IPageService {
   // Billing-aware helpers
   checkPublishLimit(keyId: string, id: string, subdomain?: string): LimitCheckResult;
   trackPageCreation(keyId: string): void;
+  reservePageQuota(keyId: string): { allowed: boolean; reason?: string; plan: Plan };
+  releasePageQuota(keyId: string): void;
 
   // Video helpers
   saveVideoFile(id: string, buffer: Buffer, mimeType: string, subdomain?: string): Promise<string>;
@@ -88,6 +90,7 @@ export interface ISubdomainService {
   // Billing-aware helpers
   checkClaimLimit(keyId: string): LimitCheckResult;
   trackSubdomainClaim(keyId: string): void;
+  reserveAndClaim(name: string, ownerKeyId: string | undefined, plan: Plan): { allowed: boolean; reason?: string; created: boolean; subdomain?: Subdomain };
 
   // Validation
   validateName(name: string): { valid: boolean; error?: string };
@@ -138,7 +141,7 @@ export interface IVideoService {
   save(id: string, buffer: Buffer, mimeType: string, subdomain?: string): Promise<string>;
   delete(path: string): Promise<void>;
   exists(path: string): boolean;
-  getPath(id: string, subdomain?: string): string;
+  getPath(relativePath: string): string;
   getMimeType(path: string): string | undefined;
 }
 

--- a/src/services/pageService.ts
+++ b/src/services/pageService.ts
@@ -19,9 +19,12 @@ import {
   incrementAgentKeyUsage,
   decrementSubdomainPageCount as dbDecrementSubdomainPageCount,
   incrementSubdomainPageCount as dbIncrementSubdomainPageCount,
+  reservePageQuota as dbReservePageQuota,
+  releasePageQuota as dbReleasePageQuota,
   getAgentKey,
 } from '../storage/db.js';
 import type { PageSummary } from '../storage/db.js';
+import type { Plan } from '../types.js';
 import { deleteVideo, saveVideo } from '../storage/video.js';
 import { checkPageLimit, getPlanFromKey, isBillingCycleExpired } from '../rules.js';
 import { config } from '../config.js';
@@ -116,6 +119,19 @@ export class PageService implements IPageService {
    */
   trackPageCreation(keyId: string): void {
     incrementAgentKeyUsage(keyId, 'monthlyPageCount');
+  }
+
+  /**
+   * Atomically check + reserve a page-quota slot for a new page.
+   * Returns { allowed:false, reason } when the plan limit is reached.
+   */
+  reservePageQuota(keyId: string): { allowed: boolean; reason?: string; plan: Plan } {
+    return dbReservePageQuota(keyId, config.freeTier.monthlyWindowMs);
+  }
+
+  /** Release a reserved page-quota slot (publish failed / no-op). */
+  releasePageQuota(keyId: string): void {
+    dbReleasePageQuota(keyId);
   }
 
   /**

--- a/src/services/subdomainService.ts
+++ b/src/services/subdomainService.ts
@@ -11,12 +11,14 @@ import {
   getSubdomainCount as dbGetSubdomainCount,
   incrementSubdomainPageCount as dbIncrementSubdomainPageCount,
   decrementSubdomainPageCount as dbDecrementSubdomainPageCount,
+  reserveAndClaimSubdomain as dbReserveAndClaimSubdomain,
+  countSubdomainsByOwner as dbCountSubdomainsByOwner,
   incrementAgentKeyUsage,
   getAgentKey,
 } from '../storage/db.js';
 import { config } from '../config.js';
 import { checkSubdomainLimit, getPlanFromKey } from '../rules.js';
-import type { Subdomain, SubdomainResult, LimitCheckResult } from '../types.js';
+import type { Subdomain, SubdomainResult, LimitCheckResult, Plan } from '../types.js';
 import type { ISubdomainService } from './interfaces.js';
 
 export class SubdomainService implements ISubdomainService {
@@ -48,11 +50,26 @@ export class SubdomainService implements ISubdomainService {
 
   /**
    * Check if a subdomain claim is allowed under the current plan.
+   * Enforced against the number of subdomains the key actually OWNS (a stable
+   * ownership cap), not a monthly counter that resets every billing cycle.
    */
   checkClaimLimit(keyId: string): LimitCheckResult {
     const agentKey = getAgentKey(keyId);
     const plan = agentKey ? getPlanFromKey(agentKey) : 'free';
-    return checkSubdomainLimit(plan, agentKey?.monthlySubdomainCount || 0);
+    return checkSubdomainLimit(plan, keyId ? dbCountSubdomainsByOwner(keyId) : 0);
+  }
+
+  /**
+   * Atomically enforce the ownership cap and claim the subdomain in one
+   * transaction (closes the concurrent-claim race). created=false means the
+   * name already existed.
+   */
+  reserveAndClaim(
+    name: string,
+    ownerKeyId: string | undefined,
+    plan: Plan,
+  ): { allowed: boolean; reason?: string; created: boolean; subdomain?: Subdomain } {
+    return dbReserveAndClaimSubdomain(name, ownerKeyId, plan);
   }
 
   /**

--- a/src/services/videoService.ts
+++ b/src/services/videoService.ts
@@ -25,8 +25,11 @@ export class VideoService implements IVideoService {
     return dbVideoExists(path);
   }
 
-  getPath(id: string, subdomain?: string): string {
-    return dbGetVideoPath(id);
+  // Resolve a stored relative video path (e.g. "sub/id.mp4") to its absolute
+  // filesystem path. The argument is the value persisted in page.video, not a
+  // bare id — passing an id would yield a wrong path.
+  getPath(relativePath: string): string {
+    return dbGetVideoPath(relativePath);
   }
 
   getMimeType(path: string): string | undefined {

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -1,6 +1,8 @@
 import crypto from 'node:crypto';
 import { open, Database } from 'lmdb';
 import { config } from '../config.js';
+import { deleteVideo } from './video.js';
+import { PLAN_LIMITS, isBillingCycleExpired } from '../rules.js';
 import type {
   Page,
   PageAuth,
@@ -465,6 +467,8 @@ export function listPagesBySubdomainPaginated(
 
   // Cursor is the last page ID (within this subdomain) from the previous page
   const startAfterKey = cursor ? `${subdomain}:${cursor}` : undefined;
+  // Whether at least one post-cursor entry exists beyond the current page.
+  let hasMore = false;
 
   for (const key of pagesDb.getKeys({ start: prefix })) {
     if (!key.startsWith(prefix)) break;
@@ -493,11 +497,17 @@ export function listPagesBySubdomainPaginated(
           etag: page.etag,
         });
       }
+    } else {
+      // A post-cursor entry exists past this page → there is a next page.
+      hasMore = true;
     }
   }
 
+  // Only emit a cursor when there is genuinely more after the last returned
+  // page (previously `total > pages.length` was true on the final page too,
+  // since `total` counts the whole collection, causing a spurious empty fetch).
   const lastPage = pages.length > 0 ? pages[pages.length - 1] : null;
-  const nextCursor = total > pages.length && lastPage ? lastPage.id : null;
+  const nextCursor = hasMore && lastPage ? lastPage.id : null;
 
   return { pages, total, next_cursor: nextCursor };
 }
@@ -535,9 +545,21 @@ export async function deleteSubdomain(name: string): Promise<boolean> {
   const pagesDb = getDatabase();
   const prefix = `${name}:`;
   for (const key of pagesDb.getKeys({ start: prefix })) {
-    if (key.startsWith(prefix)) {
-      pagesDb.removeSync(key);
+    if (!key.startsWith(prefix)) break;
+    const page = pagesDb.get(key);
+    if (!page) continue;
+
+    // Maintain every index and clean up video files, mirroring deletePage —
+    // a raw removeSync here would leave phantom index entries and orphan videos.
+    removePageFromOwnerIndex(page);
+    removePageFromRecipientIndex(page);
+    if (page.attestation) {
+      removePageFromAttestationIndexes(page);
     }
+    if (page.video) {
+      await deleteVideo(page.video);
+    }
+    pagesDb.removeSync(key);
   }
 
   getSubdomainDatabase().removeSync(name);
@@ -675,26 +697,47 @@ export async function touchAgentKey(keyId: string): Promise<void> {
 
 export async function registerUsedNonce(keyId: string, nonce: string, expiresAt: string): Promise<boolean> {
   const nonceKey = nonceStorageKey(keyId, nonce);
-  const existing = getNonceDatabase().get(nonceKey);
-  const now = new Date();
+  const nDb = getNonceDatabase();
+  const now = Date.now();
 
-  if (existing) {
-    if (new Date(existing.expires_at).getTime() > now.getTime()) {
-      return false;
+  // Atomic insert-if-absent: the get-check-put runs inside one transaction so
+  // concurrent replays of the same captured signature cannot all succeed.
+  return nDb.transactionSync(() => {
+    const existing = nDb.get(nonceKey);
+    if (existing && new Date(existing.expires_at).getTime() > now) {
+      return false; // still-valid nonce already used → replay
     }
-    getNonceDatabase().removeSync(nonceKey);
+
+    const record: NonceRecord = {
+      id: nonceKey,
+      keyId,
+      nonce,
+      created_at: new Date(now).toISOString(),
+      expires_at: expiresAt,
+    };
+    nDb.putSync(nonceKey, record);
+    return true;
+  });
+}
+
+/**
+ * Remove expired nonce records. Without this the nonce store grows linearly
+ * with every signed request ever made (honest clients never re-present a
+ * nonce, so the inline cleanup in registerUsedNonce never fires for them).
+ * Call periodically from the server entry point.
+ */
+export function cleanupExpiredNonces(): number {
+  const nDb = getNonceDatabase();
+  const now = Date.now();
+  let removed = 0;
+  for (const key of nDb.getKeys()) {
+    const rec = nDb.get(key);
+    if (rec && new Date(rec.expires_at).getTime() <= now) {
+      nDb.removeSync(key);
+      removed++;
+    }
   }
-
-  const record: NonceRecord = {
-    id: nonceKey,
-    keyId,
-    nonce,
-    created_at: now.toISOString(),
-    expires_at: expiresAt,
-  };
-
-  getNonceDatabase().putSync(nonceKey, record);
-  return true;
+  return removed;
 }
 
 export async function saveAuditLog(record: Omit<AuditLogRecord, 'id' | 'created_at'>): Promise<AuditLogRecord> {
@@ -891,14 +934,16 @@ export function listPagesByRecipient(
 function attestationSubjectIndexKey(page: Page): string {
   const subjectId = page.attestation!.subject.id;
   const ownerKeyId = page.ownerKeyId || '';
-  return `${encodeURIComponent(subjectId)}:${ownerKeyId}`;
+  const storageKey = page.subdomain ? `${page.subdomain}:${page.id}` : page.id;
+  return `${encodeURIComponent(subjectId)}:${ownerKeyId}:${storageKey}`;
 }
 
 function attestationTypeSubjectIndexKey(page: Page): string {
   const att = page.attestation!;
   const subjectId = att.subject.id;
   const ownerKeyId = page.ownerKeyId || '';
-  return `${att.type}:${encodeURIComponent(subjectId)}:${ownerKeyId}`;
+  const storageKey = page.subdomain ? `${page.subdomain}:${page.id}` : page.id;
+  return `${att.type}:${encodeURIComponent(subjectId)}:${ownerKeyId}:${storageKey}`;
 }
 
 export function addPageToAttestationIndexes(page: Page): void {
@@ -978,7 +1023,7 @@ export function listAttestationsBySubject(
 
   const lastPage = pages.length > 0 ? pages[pages.length - 1] : null;
   const nextCursor = total > pages.length && lastPage
-    ? `${encodedSubjectId}:${lastPage.ownerKeyId}`
+    ? `${encodedSubjectId}:${lastPage.ownerKeyId}:${lastPage.subdomain ? lastPage.subdomain + ':' : ''}${lastPage.id}`
     : null;
 
   return { pages, total, next_cursor: nextCursor };
@@ -1018,7 +1063,7 @@ export function listAttestationsByTypeAndSubject(
 
   const lastPage = pages.length > 0 ? pages[pages.length - 1] : null;
   const nextCursor = total > pages.length && lastPage
-    ? `${type}:${encodedSubjectId}:${lastPage.ownerKeyId}`
+    ? `${type}:${encodedSubjectId}:${lastPage.ownerKeyId}:${lastPage.subdomain ? lastPage.subdomain + ':' : ''}${lastPage.id}`
     : null;
 
   return { pages, total, next_cursor: nextCursor };
@@ -1100,6 +1145,116 @@ export async function resetAgentKeyUsage(keyId: string): Promise<void> {
     monthlySubdomainCount: 0,
     billingCycleStart: nowIso(),
     updated_at: nowIso(),
+  });
+}
+
+/**
+ * Atomically check the page quota and reserve one slot for a NEW page.
+ * Resetting an expired billing cycle, the limit check, and the increment all
+ * happen inside one LMDB transaction so concurrent publishes cannot each pass
+ * the check before any increment lands. Call releasePageQuota on failure paths.
+ */
+export function reservePageQuota(
+  keyId: string,
+  windowMs: number,
+): { allowed: boolean; reason?: string; plan: Plan } {
+  const akDb = getAgentKeyDatabase();
+  return akDb.transactionSync(() => {
+    const existing = akDb.get(keyId);
+    // Unknown key: nothing to meter (mirrors prior free/0 fallback behaviour).
+    if (!existing) return { allowed: true, plan: 'free' as Plan };
+
+    let rec = existing;
+    if (isBillingCycleExpired(existing.billingCycleStart, windowMs)) {
+      rec = { ...existing, monthlyPageCount: 0, monthlySubdomainCount: 0, billingCycleStart: nowIso() };
+    }
+    const plan: Plan = rec.plan || 'free';
+    const limit = PLAN_LIMITS[plan].pagesPerMonth;
+    const count = rec.monthlyPageCount || 0;
+    if (count >= limit) {
+      // Persist the cycle reset even when rejecting, so the window advances.
+      if (rec !== existing) akDb.putSync(keyId, { ...rec, updated_at: nowIso() });
+      return {
+        allowed: false,
+        reason: `Free tier limit of ${limit} pages per month exceeded. Upgrade to Pro for unlimited pages.`,
+        plan,
+      };
+    }
+    akDb.putSync(keyId, { ...rec, monthlyPageCount: count + 1, updated_at: nowIso() });
+    return { allowed: true, plan };
+  });
+}
+
+/** Release a previously reserved page slot (e.g. the publish failed). */
+export function releasePageQuota(keyId: string): void {
+  const akDb = getAgentKeyDatabase();
+  akDb.transactionSync(() => {
+    const existing = akDb.get(keyId);
+    if (!existing) return;
+    const count = existing.monthlyPageCount || 0;
+    if (count <= 0) return;
+    akDb.putSync(keyId, { ...existing, monthlyPageCount: count - 1, updated_at: nowIso() });
+  });
+}
+
+/** Count subdomains actually owned by a key (used for the ownership cap). */
+export function countSubdomainsByOwner(ownerKeyId: string): number {
+  const sdDb = getSubdomainDatabase();
+  let owned = 0;
+  for (const key of sdDb.getKeys()) {
+    const s = sdDb.get(key);
+    if (s?.ownerKeyId === ownerKeyId) owned++;
+  }
+  return owned;
+}
+
+/**
+ * Atomically enforce the subdomain ownership cap and claim the name in one
+ * transaction. The cap is checked against the number of subdomains the key
+ * actually owns (not a monthly counter that resets), and the claim is written
+ * inside the same transaction so two concurrent claims cannot both pass.
+ */
+export function reserveAndClaimSubdomain(
+  name: string,
+  ownerKeyId: string | undefined,
+  plan: Plan,
+): { allowed: boolean; reason?: string; created: boolean; subdomain?: Subdomain } {
+  const sdDb = getSubdomainDatabase();
+  return sdDb.transactionSync(() => {
+    const existing = sdDb.get(name);
+    if (existing) {
+      return { allowed: true, created: false, subdomain: existing };
+    }
+
+    const limit = PLAN_LIMITS[plan].subdomains;
+    if (limit !== Infinity && ownerKeyId) {
+      let owned = 0;
+      for (const key of sdDb.getKeys()) {
+        const s = sdDb.get(key);
+        if (s?.ownerKeyId === ownerKeyId) {
+          owned++;
+          if (owned >= limit) break;
+        }
+      }
+      if (owned >= limit) {
+        return {
+          allowed: false,
+          created: false,
+          reason: `${plan === 'free' ? 'Free tier' : 'Pro plan'} limit of ${limit} subdomain${limit !== 1 ? 's' : ''} reached. Upgrade for more.`,
+        };
+      }
+    }
+
+    const now = nowIso();
+    const subdomain: Subdomain = {
+      name,
+      created_at: now,
+      updated_at: now,
+      page_count: 0,
+      ownerKeyId,
+    };
+    sdDb.putSync(name, subdomain);
+    return { allowed: true, created: true, subdomain };
   });
 }
 

--- a/src/test/cap-attestation.test.ts
+++ b/src/test/cap-attestation.test.ts
@@ -39,11 +39,11 @@ let carol: TestSigner;
 function signedGet(signer: TestSigner, path: string): Request {
   const timestamp = new Date().toISOString();
   const nonce = `nonce-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-  const pathForSigning = path.split('?')[0];
+  // Signature now covers the full request target (path + query string).
   const headers = createSignedHeaders({
     signer,
     method: 'GET',
-    path: pathForSigning,
+    path,
     body: '',
     timestamp,
     nonce,

--- a/src/test/cap-recipient.test.ts
+++ b/src/test/cap-recipient.test.ts
@@ -34,11 +34,11 @@ let carol: TestSigner;
 function signedGet(signer: TestSigner, path: string): Request {
   const timestamp = new Date().toISOString();
   const nonce = `nonce-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-  const pathForSigning = path.split('?')[0];
+  // Signature now covers the full request target (path + query string).
   const headers = createSignedHeaders({
     signer,
     method: 'GET',
-    path: pathForSigning,
+    path,
     body: '',
     timestamp,
     nonce,

--- a/src/test/page-listing.test.ts
+++ b/src/test/page-listing.test.ts
@@ -32,13 +32,11 @@ let otherSigner: TestSigner;
 function signedGetRequest(signer: TestSigner, path: string): Request {
   const timestamp = new Date().toISOString();
   const nonce = `nonce-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-  // Strip query params from the path used for signing (c.req.path doesn't include them)
-  const pathForSigning = path.split('?')[0];
-
+  // The signature now covers the full request target (path + query string).
   const headers = createSignedHeaders({
     signer,
     method: 'GET',
-    path: pathForSigning,
+    path,
     body: '',
     timestamp,
     nonce,

--- a/src/test/subdomain-service.test.ts
+++ b/src/test/subdomain-service.test.ts
@@ -65,21 +65,20 @@ describe('SubdomainService', () => {
   });
 
   describe('checkClaimLimit', () => {
-    it('should allow claim for free plan under limit', () => {
-      const result = subdomainService.checkClaimLimit(freeSigner.keyId);
-      // Free plan allows 1 subdomain; we already created one, but count is monthlySubdomainCount
-      // which starts at 0, so this should be allowed
+    it('should allow claim for free plan under limit', async () => {
+      // The cap is enforced against subdomains actually OWNED by the key.
+      // A fresh key owns none, so it is under the free limit of 1.
+      const freshSigner = await createTestSigner(`sub-svc-fresh-${Date.now()}`);
+      const result = subdomainService.checkClaimLimit(freshSigner.keyId);
       expect(result.allowed).toBe(true);
     });
 
-    it('should block claim for free plan over limit', async () => {
-      // Increment usage via the key service to reach the limit
-      await services_keys.incrementUsage(freeSigner.keyId, 'monthlySubdomainCount');
+    it('should block claim for free plan over limit', () => {
+      // freeSigner already owns 'mysite' (created above), reaching the free
+      // ownership cap of 1 — a further claim must be rejected.
       const result = subdomainService.checkClaimLimit(freeSigner.keyId);
       expect(result.allowed).toBe(false);
       expect(result.reason).toContain('Free tier');
-      // Reset
-      await services_keys.resetUsage(freeSigner.keyId);
     });
 
     it('should always allow pro plan claims', () => {

--- a/src/utils/httpSignature.ts
+++ b/src/utils/httpSignature.ts
@@ -10,6 +10,12 @@ export interface SignatureHeaders {
   signature: string;
 }
 
+/**
+ * Build the canonical string that gets signed.
+ * `path` MUST be the full request target — pathname plus query string (e.g.
+ * "/v1/pages?cursor=abc&limit=20") — so query parameters are covered by the
+ * signature. For query-less requests this is just the pathname.
+ */
 export function buildCanonicalRequest(input: {
   method: string;
   path: string;

--- a/src/utils/provenance.ts
+++ b/src/utils/provenance.ts
@@ -2,6 +2,16 @@ import type { Context } from 'hono';
 import type { Page } from '../storage/db.js';
 import type { Attestation } from '../types.js';
 
+/** Escape a value for safe use inside a double-quoted HTML attribute. */
+function escapeHtmlAttr(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 /**
  * Inject CAP Protocol provenance meta tags into HTML.
  * Adds <meta> tags for key-id, signature, digest, version, and recipient.
@@ -12,29 +22,32 @@ export function injectProvenanceMeta(html: string, page: Page): string {
   }
 
   const metaTags: string[] = [];
+  const meta = (name: string, content: string) => {
+    metaTags.push(`  <meta name="${name}" content="${escapeHtmlAttr(content)}">`);
+  };
   if (page.ownerKeyId) {
-    metaTags.push(`  <meta name="cap:key-id" content="${page.ownerKeyId}">`);
-    metaTags.push(`  <meta name="cap:key-url" content="/v1/keys/${page.ownerKeyId}/jwk">`);
+    meta('cap:key-id', page.ownerKeyId);
+    meta('cap:key-url', `/v1/keys/${page.ownerKeyId}/jwk`);
   }
   if (page.publishSignature) {
-    metaTags.push(`  <meta name="cap:signature" content="${page.publishSignature}">`);
+    meta('cap:signature', page.publishSignature);
   }
   if (page.contentDigest) {
-    metaTags.push(`  <meta name="cap:digest" content="${page.contentDigest}">`);
+    meta('cap:digest', page.contentDigest);
   }
   if (page.ownerKeyId || page.publishSignature) {
-    metaTags.push(`  <meta name="cap:version" content="0.1">`);
-    metaTags.push(`  <meta name="cap:verification-url" content="/v1/verify">`);
+    meta('cap:version', '0.1');
+    meta('cap:verification-url', '/v1/verify');
   }
   if (page.recipientKeyId) {
-    metaTags.push(`  <meta name="cap:recipient-key-id" content="${page.recipientKeyId}">`);
+    meta('cap:recipient-key-id', page.recipientKeyId);
   }
 
   // Attestation meta tags
   if (page.attestation) {
-    metaTags.push(`  <meta name="cap:attestation-type" content="${page.attestation.type}">`);
-    metaTags.push(`  <meta name="cap:attestation-subject-kind" content="${page.attestation.subject.kind}">`);
-    metaTags.push(`  <meta name="cap:attestation-subject-id" content="${page.attestation.subject.id}">`);
+    meta('cap:attestation-type', page.attestation.type);
+    meta('cap:attestation-subject-kind', page.attestation.subject.kind);
+    meta('cap:attestation-subject-id', page.attestation.subject.id);
   }
 
   const provenanceBlock = metaTags.join('\n');

--- a/src/utils/ssrf.ts
+++ b/src/utils/ssrf.ts
@@ -82,6 +82,11 @@ function isPrivateIPv6(ip: string): boolean {
     return true;
   }
 
+  // :: (unspecified) — routes to localhost on most stacks
+  if (normalized === '0000:0000:0000:0000:0000:0000:0000:0000') {
+    return true;
+  }
+
   // Check for IPv4-mapped addresses in normalized form (::ffff:7f00:1 = 127.0.0.1)
   if (normalized.startsWith('0000:0000:0000:0000:0000:ffff:')) {
     const lastTwoSegments = normalized.slice(-9); // "7f00:0001"
@@ -165,39 +170,42 @@ export async function resolveAndValidate(urlString: string): Promise<{ hostname:
   const ipv4Regex = /^(\d{1,3}\.){3}\d{1,3}$/;
   const ipv6Regex = /^\[?([a-fA-F0-9:]+)\]?$/;
 
-  let ip: string;
+  let ips: string[];
 
   if (ipv4Regex.test(hostname)) {
-    ip = hostname;
+    ips = [hostname];
   } else if (ipv6Regex.test(hostname)) {
     // Remove brackets if present
-    ip = hostname.replace(/^\[|\]$/g, '');
+    ips = [hostname.replace(/^\[|\]$/g, '')];
   } else {
-    // Resolve DNS
+    // Resolve DNS — collect both A and AAAA records so we can validate every
+    // address the OS resolver might connect to.
+    const resolved: string[] = [];
     try {
-      const addresses = await dns.resolve4(hostname);
-      if (addresses.length === 0) {
-        throw new Error('No DNS records found');
-      }
-      ip = addresses[0];
-    } catch (err) {
-      // Try IPv6 if IPv4 fails
-      try {
-        const addresses = await dns.resolve6(hostname);
-        if (addresses.length === 0) {
-          throw new Error('No DNS records found');
-        }
-        ip = addresses[0];
-      } catch {
-        throw new Error('DNS resolution failed');
-      }
+      resolved.push(...await dns.resolve4(hostname));
+    } catch {
+      // no A records
+    }
+    try {
+      resolved.push(...await dns.resolve6(hostname));
+    } catch {
+      // no AAAA records
+    }
+    if (resolved.length === 0) {
+      throw new Error('DNS resolution failed');
+    }
+    ips = resolved;
+  }
+
+  // Validate EVERY resolved IP — reject if any is private/internal. This closes
+  // the multi-record bypass where only the first address was checked.
+  for (const candidate of ips) {
+    if (isPrivateIP(candidate)) {
+      throw new Error('URL resolves to a private/internal IP address');
     }
   }
 
-  // Validate the resolved IP
-  if (isPrivateIP(ip)) {
-    throw new Error('URL resolves to a private/internal IP address');
-  }
-
-  return { hostname, ip };
+  // Return the validated address so callers can pin the connection to it and
+  // avoid a second, unchecked DNS resolution (DNS-rebinding / TOCTOU).
+  return { hostname, ip: ips[0] };
 }


### PR DESCRIPTION
Remediates all 20 findings from the code review across the auth, services/storage, and route layers.

## High severity
- **Stored XSS in provenance meta tags** — all interpolated values are HTML-escaped (`provenance.ts`).
- **SSRF bypasses** (`ssrf.ts`, `proxy.ts`) — validate *all* resolved A/AAAA records, block IPv6 `::`, and pin the outgoing fetch to the validated IP via an undici dispatcher so DNS rebinding can't reach internal hosts; redirects re-pin.
- **Subdomain cascade delete** (`db.ts`) — removes owner/recipient/attestation index entries and deletes video files instead of raw key deletion.
- **Attestation index collisions** (`db.ts`) — index keys now include the page storage key; cursor reconstruction updated.

## Medium severity
- **Billing** — webhook idempotency on `checkout.session.completed`, strict subscription-id matching on deletion, duplicate-subscription guard at checkout.
- **Quota races** — atomic `transactionSync` reserve/release for page publish and an atomic claim for subdomains.
- **Subdomain cap** — enforced against subdomains actually *owned*, not the resettable monthly counter.
- **Nonce store** — atomic insert-if-absent (replay-safe) + periodic TTL sweep wired into startup.
- **Query-string signing** — canonical request now covers path + query; skill helper, example clients, docs, and tests updated.
- **Rate-limit identity** — socket-derived unless `TRUST_PROXY` is set; bounded stores.
- **Body limit** — `hono/body-limit` mounted before body buffering.
- **Subdomain error pages** — escaped and served with the sandbox CSP/security headers.
- **Admin key registration** — validates JWK + keyId and computes the fingerprint.

## Low severity
Timing-safe admin token compare; host-suffix check for subdomain routing; fixed spurious pagination cursor; distinct ETag for `/raw`; corrected `VideoService.getPath` contract; pinned `jwt.verify` to `HS256`.

## Notes
- Adds the `undici` dependency (required for SSRF connection pinning).
- `TRUST_PROXY` env var introduced — set to `true` on platforms (e.g. Render) where `X-Forwarded-For` is set by a trusted proxy.
- One test (`subdomain-service.test.ts`) asserted the old monthly-counter behavior and was updated to the corrected owned-count semantics.

## Verification
- `tsc --noEmit`: clean
- `vitest run`: **405/405 passing**
- `npm run build`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)