### PR TITLE
fix(proxy): handle both undici lookup signatures (proxy 502 regression)

### DIFF
--- a/src/routes/proxy.ts
+++ b/src/routes/proxy.ts
@@ -11,10 +11,19 @@ import { resolveAndValidate } from '../utils/ssrf.js';
  * still derived from the original URL by fetch().
  */
 function pinnedDispatcher(ip: string): Agent {
+  const family = ip.includes(':') ? 6 : 4;
   return new Agent({
     connect: {
-      lookup: (_hostname, _options, callback) => {
-        callback(null, [{ address: ip, family: ip.includes(':') ? 6 : 4 }]);
+      // undici may invoke lookup in either the `all` form (expects an array of
+      // { address, family }) or the legacy form (expects address + family
+      // positional args), depending on version. Handle both so the pinned IP
+      // is honored regardless.
+      lookup: (_hostname: string, options: any, callback: any) => {
+        if (options && options.all) {
+          callback(null, [{ address: ip, family }]);
+        } else {
+          callback(null, ip, family);
+        }
       },
     },
   });
@@ -211,7 +220,12 @@ proxy.post('/', async (c) => {
     if (err instanceof Error && err.name === 'AbortError') {
       return c.json({ error: 'Request timed out' }, 504);
     }
-    const message = err instanceof Error ? err.message : 'Failed to fetch target URL';
+    const baseMessage = err instanceof Error ? err.message : 'Failed to fetch target URL';
+    // Surface the underlying cause (e.g. ECONNREFUSED, ENOTFOUND) — "fetch
+    // failed" alone is undiagnosable.
+    const cause = (err as { cause?: { code?: string; message?: string } } | undefined)?.cause;
+    const detail = cause?.code || cause?.message;
+    const message = detail ? `${baseMessage} (${detail})` : baseMessage;
     return c.json({ error: message }, 502);
   }
 


### PR DESCRIPTION
## Problem
Production smoke test after #41 found `POST /api/proxy` returning **502 `{"error":"fetch failed"}`** for all legit requests.

Root cause: the SSRF connection-pinning dispatcher added in #41 only handled the `all: true` form of undici's custom `lookup` callback (array of `{address, family}`). Production's undici invokes `lookup` with `all: false`, expecting positional `(address, family)` args — returning an array there throws "Invalid IP address", surfacing as a generic "fetch failed". (Local undici 6.26.0 happened to use the `all: true` form, so it passed locally.)

## Fix
- `pinnedDispatcher` now handles **both** lookup signatures (checks `options.all`), so the validated IP is honored regardless of undici version. Verified locally against both forms → HTTP 200.
- Include the underlying cause (e.g. `ECONNREFUSED`, `ENOTFOUND`) in the 502 body so proxy fetch failures are diagnosable instead of opaque.

SSRF protection is unchanged — all resolved IPs are still validated and the connection is still pinned to the validated address.

## Verification
- `tsc --noEmit` clean, `npm run build` clean
- `proxy.test.ts`: 52/52 passing
- Local repro of the real flow (`resolveAndValidate` → pinned `fetch`) returns 200 for example.com and api.github.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)