### PR TITLE
fix(proxy): pin SSRF connection via connector override (fixes proxy 502)

### DIFF
--- a/src/routes/proxy.ts
+++ b/src/routes/proxy.ts
@@ -1,30 +1,23 @@
 import { Hono } from 'hono';
-import { Agent } from 'undici';
+import { Agent, buildConnector } from 'undici';
 import { config } from '../config.js';
 import { validateProxyRequest, ProxyRequest } from '../utils/validation.js';
 import { resolveAndValidate } from '../utils/ssrf.js';
 
+// Default undici connector, wrapped below to dial a pre-validated IP.
+const baseConnector = buildConnector({});
+
 /**
  * Build an undici dispatcher that pins every connection to a pre-validated IP,
  * so the network stack cannot re-resolve the hostname to a different (e.g.
- * rebound, private) address after our SSRF check. The Host header / SNI is
- * still derived from the original URL by fetch().
+ * rebound, private) address after our SSRF check. We override the connector to
+ * dial the validated IP directly while keeping the TLS servername (SNI) and
+ * Host bound to the original hostname, so certificate validation still works.
  */
-function pinnedDispatcher(ip: string): Agent {
-  const family = ip.includes(':') ? 6 : 4;
+function pinnedDispatcher(ip: string, hostname: string): Agent {
   return new Agent({
-    connect: {
-      // undici may invoke lookup in either the `all` form (expects an array of
-      // { address, family }) or the legacy form (expects address + family
-      // positional args), depending on version. Handle both so the pinned IP
-      // is honored regardless.
-      lookup: (_hostname: string, options: any, callback: any) => {
-        if (options && options.all) {
-          callback(null, [{ address: ip, family }]);
-        } else {
-          callback(null, ip, family);
-        }
-      },
+    connect(opts: any, callback: any) {
+      baseConnector({ ...opts, hostname: ip, servername: opts.servername || hostname }, callback);
     },
   });
 }
@@ -99,11 +92,12 @@ proxy.post('/', async (c) => {
     }
   }
 
-  // 6. SSRF validation (resolveAndValidate) — capture the validated IP so the
-  // outgoing fetch connects to exactly that address (no re-resolution).
+  // 6. SSRF validation (resolveAndValidate) — capture the validated IP + host so
+  // the outgoing fetch connects to exactly that address (no re-resolution).
   let pinnedIp: string;
+  let pinnedHost: string;
   try {
-    ({ ip: pinnedIp } = await resolveAndValidate(proxyReq.url));
+    ({ ip: pinnedIp, hostname: pinnedHost } = await resolveAndValidate(proxyReq.url));
   } catch (err) {
     const message = err instanceof Error ? err.message : 'SSRF validation failed';
     return c.json({ error: message }, 400);
@@ -160,7 +154,7 @@ proxy.post('/', async (c) => {
         signal: controller.signal,
         redirect: 'manual',
         // Pin the connection to the validated IP for the current URL.
-        dispatcher: pinnedDispatcher(pinnedIp),
+        dispatcher: pinnedDispatcher(pinnedIp, pinnedHost),
       };
 
       // Only include body on first request and if method supports it
@@ -182,7 +176,7 @@ proxy.post('/', async (c) => {
 
         // Validate redirect target for SSRF and re-pin to its validated IP.
         try {
-          ({ ip: pinnedIp } = await resolveAndValidate(redirectUrl));
+          ({ ip: pinnedIp, hostname: pinnedHost } = await resolveAndValidate(redirectUrl));
         } catch (err) {
           clearTimeout(timeoutId);
           const message = err instanceof Error ? err.message : 'SSRF validation failed on redirect';


### PR DESCRIPTION
## Problem
After #42, production smoke test showed `POST /api/proxy` **still 502-ing** — now with the surfaced cause `fetch failed (UND_ERR_INVALID_ARG)`.

Root cause: in undici 6 the `connect` option's `lookup` is forwarded straight to Node's `net.connect`/`tls.connect`, whose lookup-callback contract differs across the net-vs-tls paths and undici/Node versions. The custom `lookup` worked against local undici but undici in the deployed environment rejected it with `UND_ERR_INVALID_ARG`.

## Fix
Stop relying on the `lookup` signature. Override undici's **connector** via the stable `buildConnector` API: dial the pre-validated IP directly while keeping the TLS `servername` (SNI) and Host bound to the original hostname, so certificate validation still works.

```ts
const baseConnector = buildConnector({});
function pinnedDispatcher(ip, hostname) {
  return new Agent({
    connect(opts, cb) {
      baseConnector({ ...opts, hostname: ip, servername: opts.servername || hostname }, cb);
    },
  });
}
```

SSRF protection is unchanged: `resolveAndValidate` still validates every resolved IP and rejects private/loopback/IPv6-`::1`/link-local before any fetch; the connector then pins to the validated IP (no re-resolution / rebinding). Redirects are re-validated and re-pinned.

## Verification
- `tsc --noEmit` clean, `npm run build` clean, `proxy.test.ts` 52/52
- Local e2e: `example.com`, `api.github.com` (https), `neverssl.com` (http) all 200 through the pinned connector; `169.254.169.254`, `127.0.0.1`, `[::1]`, `10.0.0.1` all blocked.
- The cause-surfacing 502 diagnostic from #42 is retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)