### PR TITLE
fix(proxy): use undici's own fetch (real fix for proxy 502 / UND_ERR_INVALID_ARG)

### DIFF
--- a/src/routes/proxy.ts
+++ b/src/routes/proxy.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { Agent, buildConnector } from 'undici';
+import { Agent, buildConnector, fetch as undiciFetch } from 'undici';
 import { config } from '../config.js';
 import { validateProxyRequest, ProxyRequest } from '../utils/validation.js';
 import { resolveAndValidate } from '../utils/ssrf.js';
@@ -141,14 +141,14 @@ proxy.post('/', async (c) => {
 
   let currentUrl = proxyReq.url;
   let redirectCount = 0;
-  let response: Response | null = null;
+  let response: Awaited<ReturnType<typeof undiciFetch>> | null = null;
 
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeout);
 
   try {
     while (redirectCount <= maxRedirects) {
-      const fetchOptions: RequestInit & { dispatcher?: Agent } = {
+      const fetchOptions: Parameters<typeof undiciFetch>[1] = {
         method: redirectCount === 0 ? method : 'GET', // Follow redirects with GET
         headers: outgoingHeaders,
         signal: controller.signal,
@@ -159,10 +159,13 @@ proxy.post('/', async (c) => {
 
       // Only include body on first request and if method supports it
       if (redirectCount === 0 && proxyReq.body !== undefined && !['GET', 'HEAD'].includes(method)) {
-        fetchOptions.body = JSON.stringify(proxyReq.body);
+        fetchOptions!.body = JSON.stringify(proxyReq.body);
       }
 
-      response = await fetch(currentUrl, fetchOptions);
+      // Use undici's own fetch so the dispatcher (also undici) is the SAME
+      // version. Passing an npm-undici Agent to Node's built-in global fetch
+      // fails with UND_ERR_INVALID_ARG when the two undici versions differ.
+      response = await undiciFetch(currentUrl, fetchOptions);
 
       // Check for redirect
       if ([301, 302, 303, 307, 308].includes(response.status)) {


### PR DESCRIPTION
## Root cause (the real one)
The proxy passed an **npm-`undici` `Agent`** as the `dispatcher` to Node's **built-in global `fetch`**. Built-in fetch validates the dispatcher against *its own* bundled undici's `Dispatcher` class. When the npm undici version differs from Node's bundled undici, the Agent is a different class and is rejected with `UND_ERR_INVALID_ARG` — **before any of our lookup/connector code runs**.

This explains everything we saw:
- Worked locally (local Node's bundled undici ≈ npm undici 6.26.0).
- **#42** (handle both lookup forms) and **#43** (connector override) both produced the *identical* `UND_ERR_INVALID_ARG`, because the failure happens at dispatcher validation, upstream of that code.

## Fix
Call **undici's own `fetch`** (`import { fetch as undiciFetch } from 'undici'`) so the dispatcher and fetch come from the same undici instance. One line of behavior change; SSRF validation and connector-based IP pinning are unchanged.

## Why this is verified, unlike the prior two
`proxy.test.ts` doesn't mock fetch — it only covers validation/SSRF/allowlist paths that return before the network call, so it never exercised a real proxied request (which is why it stayed green through the regression). This fix was verified with a **real end-to-end test**: undici `fetch` + the pinned dispatcher + the exact response-handling path (`body.getReader()`, `headers.forEach`) → 200 for `example.com`/`api.github.com`; SSRF targets (`169.254.169.254`, `127.0.0.1`, `[::1]`, `10.0.0.1`) still blocked.

- `tsc --noEmit` clean, `npm run build` clean, `proxy.test.ts` 52/52.

## Follow-up (not in this PR)
Consider pinning the Node version in `render.yaml`/`engines` so the bundled-undici drift can't bite other global-fetch usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)