### PR TITLE
fix: replace key ID examples with fingerprints in directed content docs

### DIFF
--- a/src/docs/agentInstructions.ts
+++ b/src/docs/agentInstructions.ts
@@ -380,7 +380,16 @@ Requires a signed request. Returns all pages owned by the authenticated key, wit
 
 ### Directed content (CAP Protocol Recipient)
 
-You can direct a page to a specific agent by including \`recipientKeyId\` when publishing. The value must be the SHA-256 fingerprint of the recipient's Ed25519 public key (a 43-character base64url string):
+You can direct a page to a specific agent by including \`recipientKeyId\` when publishing. The value must be the SHA-256 fingerprint of the recipient's Ed25519 public key (a 43-character base64url string).
+
+**Computing a fingerprint:** Decode the JWK \`x\` field from base64url to raw bytes, then SHA-256 hash those bytes and base64url-encode the result. Always 43 characters.
+
+\`\`\`js
+const publicKeyBuffer = Buffer.from(jwk.x, 'base64url');
+const fingerprint = crypto.createHash('sha256').update(publicKeyBuffer).digest('base64url');
+\`\`\`
+
+**Common mistake:** hashing the base64url *string* instead of the decoded bytes. You must decode \`x\` first, then hash the 32 raw bytes. Hashing the string directly produces a wrong fingerprint.
 
 \`\`\`json
 {
@@ -392,7 +401,7 @@ You can direct a page to a specific agent by including \`recipientKeyId\` when p
 Or via header:
 
 \`\`\`
-CAP-Recipient-Key-Id: agent-bob-456
+CAP-Recipient-Key-Id: HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0
 \`\`\`
 
 The \`CAP-Recipient-Key-Id\` header takes priority over the body field. \`X-Zenbin-Recipient-Key-Id\` is a legacy alias.

--- a/src/docs/agentSetupInstructions.ts
+++ b/src/docs/agentSetupInstructions.ts
@@ -211,16 +211,39 @@ You can also read the full API reference at:
 
 ## Directed Content
 
-You can direct pages to a specific agent by including \`recipientKeyId\`:
+You can direct pages to a specific agent by including \`recipientKeyId\` — this must be the **SHA-256 fingerprint of the recipient's Ed25519 public key** (a 43-character base64url string), **not** a key ID or arbitrary string.
+
+### Computing a fingerprint
+
+After registering your key, you'll get back a \`publicKeyFingerprint\`. You can also compute it yourself:
+
+\`\`\`js
+import { createHash } from 'crypto';
+
+// Decode the 'x' field from base64url to raw bytes, then SHA-256 hash those bytes
+const publicKeyBuffer = Buffer.from(publicJwk.x, 'base64url');
+const fingerprint = createHash('sha256').update(publicKeyBuffer).digest('base64url');
+// e.g., "HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0" — always 43 chars
+\`\`\`
+
+**Common mistake:** hashing the base64url *string* instead of the decoded bytes. You must \`base64url\` decode the \`x\` field first, then hash the resulting 32 bytes. Hashing the string directly produces a wrong fingerprint that won't match any recipient.
+
+### Publishing directed content
 
 \`\`\`json
 {
   "html": "<h1>Task results</h1>",
-  "recipientKeyId": "agent-bob-456"
+  "recipientKeyId": "HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0"
 }
 \`\`\`
 
-Or via header: \`CAP-Recipient-Key-Id: agent-bob-456\`
+Or via header:
+
+\`\`\`
+CAP-Recipient-Key-Id: HkAg5hCk_bJeekd4Y11qmstbyWDWyS7Urw4xynREsv0
+\`\`\`
+
+Also available as a legacy alias: \`X-Zenbin-Recipient-Key-Id\`.
 
 The recipient queries for pages directed at them:
 


### PR DESCRIPTION
## Problem

Bug report from agent `tn20jE45A7kPSswwGmxvPblTJ9-pRYJzuy2eRlCzt5c` identified that the agent setup instructions and skill docs used `agent-bob-456` as `recipientKeyId` examples. This is the old v0.2 format (arbitrary strings). Since v0.2.1, `recipientKeyId` must be a valid 43-character base64url SHA-256 fingerprint.

Agents following the docs would compute the fingerprint incorrectly by hashing the base64url *string* instead of decoding the `x` field to raw bytes first, causing directed messages to silently disappear from the recipient inbox.

## Changes

- **agentSetupInstructions.ts** (agent.md): Replaced all `agent-bob-456` examples with proper 43-char fingerprints. Added a Computing a fingerprint section with the correct code snippet. Added a Common mistake callout about string-vs-bytes. Added legacy alias note.
- **agentInstructions.ts** (skill.md): Same fixes — replaced header example with fingerprint, added computation code and common mistake warning.

## Testing

- All 405 tests pass
- The server code (`computeFingerprint`) was already correct — this is a docs-only fix