### PR TITLE
feat: add PATCH /v1/admin/keys/:keyId/plan endpoint

### DIFF
--- a/src/routes/adminKeys.ts
+++ b/src/routes/adminKeys.ts
@@ -4,6 +4,7 @@ import { requireAdmin } from '../middleware/adminAuth.js';
 import { validateEd25519PublicJwk } from '../utils/httpSignature.js';
 import { computeFingerprint } from '../utils/fingerprint.js';
 import type { Services } from '../services/container.js';
+import type { Plan } from '../types.js';
 
 const adminKeys = new Hono();
 
@@ -166,6 +167,50 @@ adminKeys.get('/:keyId/audit', async (c) => {
 
   const logs = services.audit.listForKey(keyId);
   return c.json({ logs });
+});
+
+// PATCH /v1/admin/keys/:keyId/plan — Update key plan
+adminKeys.patch('/:keyId/plan', async (c) => {
+  const keyId = c.req.param('keyId');
+  const services = getServices(c);
+
+  let body: { plan?: string; resetUsage?: boolean };
+  try {
+    body = await c.req.json();
+  } catch {
+    return errorResponse(ErrorCodes.INVALID_JSON, 'Invalid JSON body', 400);
+  }
+
+  if (!body.plan || !['free', 'pro', 'enterprise'].includes(body.plan)) {
+    return errorResponse(ErrorCodes.INVALID_REQUEST, 'plan must be one of: free, pro, enterprise', 400);
+  }
+
+  const existing = services.keys.get(keyId);
+  if (!existing) {
+    return errorResponse(ErrorCodes.KEY_NOT_FOUND, 'Key not found', 404);
+  }
+
+  const updated = await services.keys.updatePlan(keyId, body.plan as Plan);
+
+  if (body.resetUsage) {
+    await services.keys.resetUsage(keyId);
+  }
+
+  await services.audit.save({
+    action: 'admin_update_plan',
+    targetType: 'agent_key',
+    keyId,
+    status: 'accepted',
+    metadata: { plan: body.plan, resetUsage: String(!!body.resetUsage) },
+  });
+
+  return c.json({
+    keyId: updated!.keyId,
+    plan: updated!.plan,
+    monthlyPageCount: body.resetUsage ? 0 : updated!.monthlyPageCount,
+    monthlySubdomainCount: body.resetUsage ? 0 : updated!.monthlySubdomainCount,
+    updated_at: updated!.updated_at,
+  });
 });
 
 // POST /v1/admin/keys/:keyId/block — Block a key

--- a/src/test/api.test.ts
+++ b/src/test/api.test.ts
@@ -520,6 +520,83 @@ describe('Admin key controls', () => {
     const data = await publishRes.json() as { error: string };
     expect(data.error).toContain('blocked');
   });
+
+  it('should update key plan to pro', async () => {
+    const planSigner = await createTestSigner(`plan-signer-${Date.now()}`);
+
+    // Upgrade to pro
+    const updateRes = await app.request(`/v1/admin/keys/${planSigner.keyId}/plan`, {
+      method: 'PATCH',
+      headers: {
+        'X-Admin-Token': config.admin.token,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ plan: 'pro', resetUsage: true }),
+    });
+
+    expect(updateRes.status).toBe(200);
+    const data = await updateRes.json() as { keyId: string; plan: string; monthlyPageCount: number; monthlySubdomainCount: number };
+    expect(data.plan).toBe('pro');
+    expect(data.monthlyPageCount).toBe(0);
+    expect(data.monthlySubdomainCount).toBe(0);
+  });
+
+  it('should update key plan to enterprise', async () => {
+    const entSigner = await createTestSigner(`ent-signer-${Date.now()}`);
+
+    const updateRes = await app.request(`/v1/admin/keys/${entSigner.keyId}/plan`, {
+      method: 'PATCH',
+      headers: {
+        'X-Admin-Token': config.admin.token,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ plan: 'enterprise' }),
+    });
+
+    expect(updateRes.status).toBe(200);
+    const data = await updateRes.json() as { keyId: string; plan: string };
+    expect(data.plan).toBe('enterprise');
+  });
+
+  it('should reject invalid plan values', async () => {
+    const invalidSigner = await createTestSigner(`invalid-plan-signer-${Date.now()}`);
+
+    const res = await app.request(`/v1/admin/keys/${invalidSigner.keyId}/plan`, {
+      method: 'PATCH',
+      headers: {
+        'X-Admin-Token': config.admin.token,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ plan: 'invalid' }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('should reject plan update without admin token', async () => {
+    const noAdminSigner = await createTestSigner(`no-admin-signer-${Date.now()}`);
+
+    const res = await app.request(`/v1/admin/keys/${noAdminSigner.keyId}/plan`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ plan: 'pro' }),
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('should return 404 for non-existent key plan update', async () => {
+    const res = await app.request('/v1/admin/keys/nonexistent-key-12345/plan', {
+      method: 'PATCH',
+      headers: {
+        'X-Admin-Token': config.admin.token,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ plan: 'pro' }),
+    });
+
+    expect(res.status).toBe(404);
+  });
 });
 
 describe('GET /p/:id', () => {


### PR DESCRIPTION
Adds admin endpoint to update agent key plan (free/pro/enterprise) with optional usage reset.

- `PATCH /v1/admin/keys/:keyId/plan` with `X-Admin-Token` header
- Body: `{"plan": "pro", "resetUsage": true}`
- 6 new tests, all 358 passing