### PR TITLE
feat: admin endpoint to transfer subdomain ownership between keys (issue #50)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import { serveLandingPage } from './routes/landing.js';
 import { billing } from './routes/billing.js';
 import { serveSubdomainPage } from './routes/subdomainRender.js';
 import { adminKeys } from './routes/adminKeys.js';
+import { adminSubdomains } from './routes/adminSubdomains.js';
 import { keys } from './routes/keys.js';
 import { verify } from './routes/verify.js';
 
@@ -170,6 +171,7 @@ app.route('/v1/stats', stats);
 app.route('/v1/keys', keys);
 app.route('/v1/verify', verify);
 app.route('/v1/admin/keys', adminKeys);
+app.route('/v1/admin/subdomains', adminSubdomains);
 app.route('/v1/billing', billing);
 
 // Agent instructions

--- a/src/routes/adminSubdomains.ts
+++ b/src/routes/adminSubdomains.ts
@@ -1,0 +1,82 @@
+import { Context, Hono } from 'hono';
+import { ErrorCodes, errorResponse } from '../errors.js';
+import { requireAdmin } from '../middleware/adminAuth.js';
+import type { Services } from '../services/container.js';
+
+const adminSubdomains = new Hono();
+
+// All admin subdomain routes require admin authentication
+adminSubdomains.use('*', requireAdmin);
+
+function getServices(c: Context): Services {
+  return c.get('services')!;
+}
+
+// DELETE /v1/admin/subdomains/:name — Release subdomain ownership.
+// Clears ownerKeyId so any key can claim it via POST /v1/subdomains/:name.
+// Does NOT delete pages. Existing pages remain accessible.
+adminSubdomains.delete('/:name', async (c) => {
+  const name = c.req.param('name').toLowerCase();
+  const services = getServices(c);
+
+  const result = services.subdomains.releaseOwnership(name);
+  if (result.error) {
+    return errorResponse(ErrorCodes.SUBDOMAIN_NOT_FOUND, result.error, result.status || 404);
+  }
+
+  await services.audit.save({
+    action: 'admin_subdomain_release',
+    targetType: 'subdomain',
+    subdomain: name,
+    status: 'accepted',
+  });
+
+  return c.json({
+    name: result.subdomain!.name,
+    ownerKeyId: result.subdomain!.ownerKeyId,
+    released: true,
+    updated_at: result.subdomain!.updated_at,
+  });
+});
+
+// PATCH /v1/admin/subdomains/:name — Transfer subdomain ownership to a new key.
+// Body: { "ownerKeyId": "new-key-id" }
+// The new key must be registered and active. Does NOT touch pages.
+adminSubdomains.patch('/:name', async (c) => {
+  const name = c.req.param('name').toLowerCase();
+  const services = getServices(c);
+
+  let body: { ownerKeyId?: string };
+  try {
+    body = await c.req.json();
+  } catch {
+    return errorResponse(ErrorCodes.INVALID_JSON, 'Invalid JSON body', 400);
+  }
+
+  if (!body.ownerKeyId || typeof body.ownerKeyId !== 'string') {
+    return errorResponse(ErrorCodes.INVALID_REQUEST, 'ownerKeyId is required', 400);
+  }
+
+  const result = services.subdomains.transferOwnership(name, body.ownerKeyId);
+  if (result.error) {
+    const code = result.status === 404 ? ErrorCodes.SUBDOMAIN_NOT_FOUND : ErrorCodes.INVALID_REQUEST;
+    return errorResponse(code, result.error, result.status || 400);
+  }
+
+  await services.audit.save({
+    action: 'admin_subdomain_transfer',
+    targetType: 'subdomain',
+    subdomain: name,
+    status: 'accepted',
+    metadata: { newOwnerKeyId: body.ownerKeyId },
+  });
+
+  return c.json({
+    name: result.subdomain!.name,
+    ownerKeyId: result.subdomain!.ownerKeyId,
+    transferred: true,
+    updated_at: result.subdomain!.updated_at,
+  });
+});
+
+export { adminSubdomains };

--- a/src/routes/subdomains.ts
+++ b/src/routes/subdomains.ts
@@ -60,7 +60,7 @@ subdomains.post('/:name', async (c) => {
   }
 
   const existing = services.subdomains.get(name);
-  if (existing) {
+  if (existing && existing.ownerKeyId) {
     return errorResponse(ErrorCodes.SUBDOMAIN_TAKEN, `Subdomain '${name}' is already taken`, 409);
   }
 

--- a/src/services/interfaces.ts
+++ b/src/services/interfaces.ts
@@ -94,6 +94,10 @@ export interface ISubdomainService {
 
   // Validation
   validateName(name: string): { valid: boolean; error?: string };
+
+  // Admin operations
+  transferOwnership(name: string, newOwnerKeyId: string): { subdomain?: Subdomain; error?: string; status?: number };
+  releaseOwnership(name: string): { subdomain?: Subdomain; error?: string; status?: number };
 }
 
 // ─── Key Service ────────────────────────────────────────────

--- a/src/services/subdomainService.ts
+++ b/src/services/subdomainService.ts
@@ -13,6 +13,8 @@ import {
   decrementSubdomainPageCount as dbDecrementSubdomainPageCount,
   reserveAndClaimSubdomain as dbReserveAndClaimSubdomain,
   countSubdomainsByOwner as dbCountSubdomainsByOwner,
+  transferSubdomainOwnership as transferSubdomainOwnershipDb,
+  releaseSubdomain as releaseSubdomainDb,
   incrementAgentKeyUsage,
   getAgentKey,
 } from '../storage/db.js';
@@ -102,5 +104,51 @@ export class SubdomainService implements ISubdomainService {
     }
 
     return { valid: true };
+  }
+
+  /**
+   * Transfer subdomain ownership to a new key.
+   * Validates the subdomain exists and the target key is registered + active.
+   * Does NOT touch pages.
+   */
+  transferOwnership(name: string, newOwnerKeyId: string): { subdomain?: Subdomain; error?: string; status?: number } {
+    const existing = this.get(name);
+    if (!existing) {
+      return { error: `Subdomain '${name}' not found`, status: 404 };
+    }
+
+    const targetKey = getAgentKey(newOwnerKeyId);
+    if (!targetKey) {
+      return { error: `Key '${newOwnerKeyId}' not found`, status: 400 };
+    }
+    if (targetKey.status !== 'active') {
+      return { error: `Key '${newOwnerKeyId}' is not active (status: ${targetKey.status})`, status: 400 };
+    }
+
+    const updated = transferSubdomainOwnershipDb(name, newOwnerKeyId);
+    if (!updated) {
+ return { error: `Subdomain '${name}' not found`, status: 404 };
+    }
+
+    return { subdomain: updated };
+  }
+
+  /**
+   * Release subdomain ownership (clear ownerKeyId).
+   * The subdomain becomes claimable by any key via POST /v1/subdomains/:name.
+   * Does NOT touch pages.
+   */
+  releaseOwnership(name: string): { subdomain?: Subdomain; error?: string; status?: number } {
+    const existing = this.get(name);
+    if (!existing) {
+      return { error: `Subdomain '${name}' not found`, status: 404 };
+    }
+
+    const updated = releaseSubdomainDb(name);
+    if (!updated) {
+      return { error: `Subdomain '${name}' not found`, status: 404 };
+    }
+
+    return { subdomain: updated };
   }
 }

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -559,6 +559,45 @@ export function getSubdomain(name: string): Subdomain | undefined {
   return getSubdomainDatabase().get(name);
 }
 
+/**
+ * Transfer subdomain ownership to a new key.
+ * Does NOT touch pages — existing pages remain accessible.
+ * Returns the updated Subdomain or undefined if not found.
+ */
+export function transferSubdomainOwnership(name: string, newOwnerKeyId: string): Subdomain | undefined {
+  const sdDb = getSubdomainDatabase();
+  const existing = sdDb.get(name);
+  if (!existing) return undefined;
+
+  const updated: Subdomain = {
+    ...existing,
+    ownerKeyId: newOwnerKeyId,
+    updated_at: nowIso(),
+  };
+  sdDb.putSync(name, updated);
+  return updated;
+}
+
+/**
+ * Release subdomain ownership (clear ownerKeyId).
+ * The subdomain record remains, pages remain accessible, but any key
+ * can claim it via POST /v1/subdomains/:name.
+ * Returns the updated Subdomain or undefined if not found.
+ */
+export function releaseSubdomain(name: string): Subdomain | undefined {
+  const sdDb = getSubdomainDatabase();
+  const existing = sdDb.get(name);
+  if (!existing) return undefined;
+
+  const updated: Subdomain = {
+    ...existing,
+    ownerKeyId: undefined,
+    updated_at: nowIso(),
+  };
+  sdDb.putSync(name, updated);
+  return updated;
+}
+
 export async function deleteSubdomain(name: string): Promise<boolean> {
   const existing = getSubdomainDatabase().get(name);
   if (!existing) {
@@ -1245,9 +1284,12 @@ export function reserveAndClaimSubdomain(
   const sdDb = getSubdomainDatabase();
   return sdDb.transactionSync(() => {
     const existing = sdDb.get(name);
-    if (existing) {
+    if (existing && existing.ownerKeyId) {
       return { allowed: true, created: false, subdomain: existing };
     }
+
+    // If the subdomain exists but has no owner (released), re-claim it.
+    // If it doesn't exist at all, create it.
 
     const limit = PLAN_LIMITS[plan].subdomains;
     if (limit !== Infinity && ownerKeyId) {
@@ -1271,9 +1313,9 @@ export function reserveAndClaimSubdomain(
     const now = nowIso();
     const subdomain: Subdomain = {
       name,
-      created_at: now,
+      created_at: existing?.created_at || now,
       updated_at: now,
-      page_count: 0,
+      page_count: existing?.page_count || 0,
       ownerKeyId,
     };
     sdDb.putSync(name, subdomain);

--- a/src/test/admin-subdomains.test.ts
+++ b/src/test/admin-subdomains.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import { pages } from '../routes/pages.js';
+import { subdomains } from '../routes/subdomains.js';
+import { adminSubdomains } from '../routes/adminSubdomains.js';
+import { initDatabase, closeDatabase, updateAgentKeyPlan } from '../storage/db.js';
+import { config } from '../config.js';
+import { rmSync } from 'fs';
+import { createSignedHeaders, createTestSigner, jsonSignedRequest, type TestSigner } from './helpers/signing.js';
+import { createServices, type Services } from '../services/container.js';
+
+const TEST_DB_PATH = './data/test-admin-subdomains.lmdb';
+const TEST_DB_SUFFIXES = ['', '-subdomains', '-agent-keys', '-nonces', '-audit', '-owner-index', '-recipient-index'];
+
+type Variables = { subdomain: string; services: Services };
+
+let testId: number;
+const uniqueId = (base: string) => `${base}-${testId++}`;
+let signer: TestSigner;
+let otherSigner: TestSigner;
+
+const services = createServices();
+
+const app = new Hono<{ Variables: Variables }>();
+app.use('*', async (c, next) => {
+  c.set('services', services);
+  await next();
+});
+app.route('/v1/pages', pages);
+app.route('/v1/subdomains', subdomains);
+app.route('/v1/admin/subdomains', adminSubdomains);
+
+beforeAll(async () => {
+  for (const suffix of TEST_DB_SUFFIXES) {
+    try {
+      rmSync(`${TEST_DB_PATH}${suffix}`, { recursive: true, force: true });
+    } catch { /* ignore */ }
+  }
+  process.env.LMDB_PATH = TEST_DB_PATH;
+  initDatabase();
+  signer = await createTestSigner(`admin-sd-owner-${Date.now()}`);
+  otherSigner = await createTestSigner(`admin-sd-other-${Date.now()}`);
+
+  await updateAgentKeyPlan(signer.keyId, 'enterprise');
+  await updateAgentKeyPlan(otherSigner.keyId, 'enterprise');
+});
+
+beforeEach(() => {
+  testId = Date.now();
+});
+
+afterAll(async () => {
+  await closeDatabase();
+  for (const suffix of TEST_DB_SUFFIXES) {
+    try {
+      rmSync(`${TEST_DB_PATH}${suffix}`, { recursive: true, force: true });
+    } catch { /* ignore */ }
+  }
+});
+
+describe('Admin Subdomain Management', () => {
+  describe('DELETE /v1/admin/subdomains/:name (release)', () => {
+    it('should release subdomain ownership (admin)', async () => {
+      const name = uniqueId('release-test');
+      // Claim with signer
+      await app.request(`/v1/subdomains/${name}`, jsonSignedRequest({ signer, method: 'POST', path: `/v1/subdomains/${name}` }));
+
+      // Release as admin
+      const res = await app.request(`/v1/admin/subdomains/${name}`, {
+        method: 'DELETE',
+        headers: { 'X-Admin-Token': config.admin.token },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json() as { name: string; ownerKeyId: string | undefined; released: boolean };
+      expect(body.name).toBe(name);
+      expect(body.released).toBe(true);
+      expect(body.ownerKeyId).toBeUndefined();
+    });
+
+    it('should reject release without admin token', async () => {
+      const name = uniqueId('no-admin-release');
+      await app.request(`/v1/subdomains/${name}`, jsonSignedRequest({ signer, method: 'POST', path: `/v1/subdomains/${name}` }));
+
+      const res = await app.request(`/v1/admin/subdomains/${name}`, {
+        method: 'DELETE',
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it('should return 404 for non-existent subdomain', async () => {
+      const res = await app.request(`/v1/admin/subdomains/nonexistent-${testId}`, {
+        method: 'DELETE',
+        headers: { 'X-Admin-Token': config.admin.token },
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it('should allow re-claim after release', async () => {
+      const name = uniqueId('reclaim-test');
+      // Claim with signer
+      await app.request(`/v1/subdomains/${name}`, jsonSignedRequest({ signer, method: 'POST', path: `/v1/subdomains/${name}` }));
+
+      // Release as admin
+      await app.request(`/v1/admin/subdomains/${name}`, {
+        method: 'DELETE',
+        headers: { 'X-Admin-Token': config.admin.token },
+      });
+
+      // Re-claim with other signer
+      const res = await app.request(`/v1/subdomains/${name}`, jsonSignedRequest({ signer: otherSigner, method: 'POST', path: `/v1/subdomains/${name}` }));
+      expect(res.status).toBe(201);
+      const body = await res.json() as { name: string };
+      expect(body.name).toBe(name);
+    });
+  });
+
+  describe('PATCH /v1/admin/subdomains/:name (transfer)', () => {
+    it('should transfer subdomain ownership (admin)', async () => {
+      const name = uniqueId('transfer-test');
+      // Claim with signer
+      await app.request(`/v1/subdomains/${name}`, jsonSignedRequest({ signer, method: 'POST', path: `/v1/subdomains/${name}` }));
+
+      // Transfer to otherSigner
+      const res = await app.request(`/v1/admin/subdomains/${name}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Admin-Token': config.admin.token,
+        },
+        body: JSON.stringify({ ownerKeyId: otherSigner.keyId }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json() as { name: string; ownerKeyId: string; transferred: boolean };
+      expect(body.name).toBe(name);
+      expect(body.transferred).toBe(true);
+      expect(body.ownerKeyId).toBe(otherSigner.keyId);
+    });
+
+    it('should reject transfer without admin token', async () => {
+      const name = uniqueId('no-admin-transfer');
+      await app.request(`/v1/subdomains/${name}`, jsonSignedRequest({ signer, method: 'POST', path: `/v1/subdomains/${name}` }));
+
+      const res = await app.request(`/v1/admin/subdomains/${name}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ownerKeyId: otherSigner.keyId }),
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it('should return 404 for non-existent subdomain', async () => {
+      const res = await app.request(`/v1/admin/subdomains/nonexistent-${testId}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Admin-Token': config.admin.token,
+        },
+        body: JSON.stringify({ ownerKeyId: otherSigner.keyId }),
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it('should return 400 for non-existent target key', async () => {
+      const name = uniqueId('invalid-key-transfer');
+      await app.request(`/v1/subdomains/${name}`, jsonSignedRequest({ signer, method: 'POST', path: `/v1/subdomains/${name}` }));
+
+      const res = await app.request(`/v1/admin/subdomains/${name}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Admin-Token': config.admin.token,
+        },
+        body: JSON.stringify({ ownerKeyId: 'nonexistent-key-12345' }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('should return 400 for missing ownerKeyId in body', async () => {
+      const name = uniqueId('missing-owner');
+      await app.request(`/v1/subdomains/${name}`, jsonSignedRequest({ signer, method: 'POST', path: `/v1/subdomains/${name}` }));
+
+      const res = await app.request(`/v1/admin/subdomains/${name}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Admin-Token': config.admin.token,
+        },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('should allow new key to publish after transfer', async () => {
+      const name = uniqueId('publish-after-transfer');
+      // Claim with signer
+      await app.request(`/v1/subdomains/${name}`, jsonSignedRequest({ signer, method: 'POST', path: `/v1/subdomains/${name}` }));
+
+      // Transfer to otherSigner
+      await app.request(`/v1/admin/subdomains/${name}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Admin-Token': config.admin.token,
+        },
+        body: JSON.stringify({ ownerKeyId: otherSigner.keyId }),
+      });
+
+      // otherSigner publishes a page under the subdomain
+      const pageHtml = '<html><head><title>Test</title></head><body><p>Published after transfer</p></body></html>';
+      const publishRes = await app.request(`/v1/pages/test-page`, {
+        ...jsonSignedRequest({ signer: otherSigner, method: 'POST', path: '/v1/pages/test-page', body: { html: pageHtml } }),
+        headers: {
+          ...jsonSignedRequest({ signer: otherSigner, method: 'POST', path: '/v1/pages/test-page', body: { html: pageHtml } }).headers,
+          'X-Subdomain': name,
+        },
+      });
+      expect(publishRes.status).toBe(201);
+    });
+
+    it('should reject old key from publishing after transfer', async () => {
+      const name = uniqueId('old-key-blocked');
+      // Claim with signer
+      await app.request(`/v1/subdomains/${name}`, jsonSignedRequest({ signer, method: 'POST', path: `/v1/subdomains/${name}` }));
+
+      // Transfer to otherSigner
+      await app.request(`/v1/admin/subdomains/${name}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Admin-Token': config.admin.token,
+        },
+        body: JSON.stringify({ ownerKeyId: otherSigner.keyId }),
+      });
+
+      // Old signer tries to publish
+      const pageHtml = '<html><head><title>Test</title></head><body><p>Old key</p></body></html>';
+      const publishRes = await app.request(`/v1/pages/test-page`, {
+        ...jsonSignedRequest({ signer, method: 'POST', path: '/v1/pages/test-page', body: { html: pageHtml } }),
+        headers: {
+          ...jsonSignedRequest({ signer, method: 'POST', path: '/v1/pages/test-page', body: { html: pageHtml } }).headers,
+          'X-Subdomain': name,
+        },
+      });
+      expect(publishRes.status).toBe(403);
+    });
+
+    it('should keep existing pages accessible after transfer', async () => {
+      const name = uniqueId('pages-survive');
+      // Claim with signer
+      await app.request(`/v1/subdomains/${name}`, jsonSignedRequest({ signer, method: 'POST', path: `/v1/subdomains/${name}` }));
+
+      // Publish a page
+      const pageHtml = '<html><head><title>Survives Transfer</title></head><body><p>Still here</p></body></html>';
+      await app.request(`/v1/pages/my-page`, {
+        ...jsonSignedRequest({ signer, method: 'POST', path: '/v1/pages/my-page', body: { html: pageHtml } }),
+        headers: {
+          ...jsonSignedRequest({ signer, method: 'POST', path: '/v1/pages/my-page', body: { html: pageHtml } }).headers,
+          'X-Subdomain': name,
+        },
+      });
+
+      // Transfer to otherSigner
+      await app.request(`/v1/admin/subdomains/${name}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Admin-Token': config.admin.token,
+        },
+        body: JSON.stringify({ ownerKeyId: otherSigner.keyId }),
+      });
+
+      // Check the subdomain still has pages
+      const pagesRes = await app.request(`/v1/subdomains/${name}/pages`, {
+        ...createSignedHeaders({ signer: otherSigner, method: 'GET', path: `/v1/subdomains/${name}/pages`, body: '' }),
+      });
+      expect(pagesRes.status).toBe(200);
+      const pagesBody = await pagesRes.json() as { pages: { id: string }[]; total: number };
+      expect(pagesBody.total).toBeGreaterThan(0);
+      expect(pagesBody.pages.some(p => p.id === 'my-page')).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Closes #50

## Changes

- **DELETE `/v1/admin/subdomains/:name`** — releases subdomain ownership (clears `ownerKeyId`). Any key can then claim it via `POST /v1/subdomains/:name`.
- **PATCH `/v1/admin/subdomains/:name`** — transfers ownership to a new `ownerKeyId`. The target key must be registered and active.
- Both require admin authentication (`X-Admin-Token`).
- Both write audit log entries.
- Neither modifies existing pages. Pages remain accessible after ownership change.
- Updated claim endpoint to allow re-claiming a released subdomain (one with no `ownerKeyId`).

## Files changed

| File | Change |
|------|--------|
| `src/routes/adminSubdomains.ts` | New route file with DELETE + PATCH endpoints |
| `src/test/admin-subdomains.test.ts` | 12 new tests |
| `src/index.ts` | Wire admin subdomain route |
| `src/routes/subdomains.ts` | Allow re-claim of released subdomain |
| `src/services/interfaces.ts` | Add `transferOwnership` + `releaseOwnership` to `ISubdomainService` |
| `src/services/subdomainService.ts` | Implement both methods with validation |
| `src/storage/db.ts` | Add `transferSubdomainOwnership` + `releaseSubdomain` DB functions; update `reserveAndClaimSubdomain` to handle re-claims |

## Test results

All 443 tests pass (25 test files), including 12 new tests covering:
- Admin release (200)
- Admin transfer (200)
- No admin token (401)
- Non-existent subdomain (404)
- Invalid target key (400)
- Missing ownerKeyId in body (400)
- Re-claim after release works (201)
- Publish after transfer works (201)
- Old key blocked from publishing after transfer (403)
- Existing pages remain accessible after transfer